### PR TITLE
Make Bijection and Pivot Serializable

### DIFF
--- a/bijection-core/src/main/scala/com/twitter/bijection/Bijection.scala
+++ b/bijection-core/src/main/scala/com/twitter/bijection/Bijection.scala
@@ -16,6 +16,7 @@ limitations under the License.
 
 package com.twitter.bijection
 
+import java.io.Serializable
 import scala.annotation.implicitNotFound
 
 /**
@@ -26,7 +27,7 @@ import scala.annotation.implicitNotFound
  */
 
 @implicitNotFound(msg = "Cannot find Bijection type class between ${A} and ${B}")
-trait Bijection[A, B] extends (A => B) { self =>
+trait Bijection[A, B] extends (A => B) with Serializable { self =>
   def apply(a: A): B
   def invert(b: B): A = inverse(b)
 

--- a/bijection-core/src/main/scala/com/twitter/bijection/Bufferable.scala
+++ b/bijection-core/src/main/scala/com/twitter/bijection/Bufferable.scala
@@ -16,6 +16,7 @@ limitations under the License.
 
 package com.twitter.bijection
 
+import java.io.Serializable
 import java.nio.{ByteBuffer, BufferOverflowException}
 import java.nio.channels.Channel
 import scala.annotation.implicitNotFound
@@ -28,7 +29,7 @@ import scala.collection.mutable.{Builder, Map => MMap, Set => MSet, Buffer => MB
  */
 
 @implicitNotFound(msg = "Cannot find Bufferable type class for ${T}")
-trait Bufferable[T] extends java.io.Serializable {
+trait Bufferable[T] extends Serializable {
   def put(into: ByteBuffer, t: T): ByteBuffer
   def get(from: ByteBuffer): T
 }
@@ -38,7 +39,7 @@ trait LowPriorityBufferable {
 
 }*/
 
-object Bufferable extends GeneratedTupleBufferable with java.io.Serializable {
+object Bufferable extends GeneratedTupleBufferable with Serializable {
   val DEFAULT_SIZE = 1024
   // Type class methods:
   def put[T](into: ByteBuffer, t: T)(implicit buf: Bufferable[T]): ByteBuffer = buf.put(into, t)

--- a/bijection-core/src/main/scala/com/twitter/bijection/Pivot.scala
+++ b/bijection-core/src/main/scala/com/twitter/bijection/Pivot.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.bijection
 
+import java.io.Serializable
+
 object Pivot {
   /**
    * Returns a new Pivot[K, K1, K2] using the supplied bijection
@@ -42,7 +44,7 @@ object Pivot {
     }
 }
 
-trait PivotEncoder[K, K1, K2] extends (Iterable[K] => Map[K1, Iterable[K2]]) {
+trait PivotEncoder[K, K1, K2] extends (Iterable[K] => Map[K1, Iterable[K2]]) with Serializable {
   def enc: (K) => (K1, K2)
   /**
    * Pivots an Iterable[K] into Map[K1, Iterable[K2]] by
@@ -67,7 +69,7 @@ trait PivotEncoder[K, K1, K2] extends (Iterable[K] => Map[K1, Iterable[K2]]) {
   }
 }
 
-trait PivotDecoder[K, K1, K2] extends (Map[K1, Iterable[K2]] => Iterable[K]) {
+trait PivotDecoder[K, K1, K2] extends (Map[K1, Iterable[K2]] => Iterable[K]) with Serializable {
   def dec: ((K1, K2)) => K
 
   /**


### PR DESCRIPTION
`Bijection` doesn't actually get this from `Function1`. This will let us remove the MeatLockers from all around summingbird.
