### PR TITLE
add "lazy" to saved method in ProtobufCodec

### DIFF
--- a/bijection-protobuf/src/main/scala/com/twitter/bijection/protobuf/ProtobufCodecs.scala
+++ b/bijection-protobuf/src/main/scala/com/twitter/bijection/protobuf/ProtobufCodecs.scala
@@ -25,7 +25,7 @@ object ProtobufCodec {
 }
 
 class ProtobufCodec[T <: Message](klass: Class[T]) extends Bijection[T, Array[Byte]] {
-  val parseFrom = klass.getMethod("parseFrom", classOf[Array[Byte]])
+  lazy val parseFrom = klass.getMethod("parseFrom", classOf[Array[Byte]])
   override def apply(item: T) = item.toByteArray
   override def invert(bytes: Array[Byte]) = parseFrom.invoke(null, bytes).asInstanceOf[T]
 }


### PR DESCRIPTION
round-tripping the saved Method through Chill's BijectiveSerializer fails without this (causes the invert to throw NPE). This fixes the bug.
