### PR TITLE
remove thrift and protobuf submodules from tests

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -76,8 +76,9 @@ object BijectionBuild extends Build {
     publish := { }, // skip publishing for this root project.
     publishLocal := { }
   ).aggregate(bijectionCore,
-              bijectionProtobuf,
-              bijectionThrift,
+              // TODO: Add back in once we can figure out how to run the tests for these on travis.
+              // bijectionProtobuf,
+              // bijectionThrift,
               bijectionJson)
 
   lazy val bijectionCore = Project(


### PR DESCRIPTION
These seem to bork thrift.
