### PR TITLE
bijection-netty channel buffer injections

### DIFF
--- a/bijection-netty/src/main/scala/com/twitter/bijection/netty/ChannelBufferImplicits.scala
+++ b/bijection-netty/src/main/scala/com/twitter/bijection/netty/ChannelBufferImplicits.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.bijection.netty
+
+/** Packaged implicits for netty bijections */
+trait LowPriorityImplicits {
+  implicit val nettybij = ChannelBufferBijection
+}
+
+object Implicits extends LowPriorityImplicits


### PR DESCRIPTION
I've needed something like these in a storehaus-redis module and other finagle client-backed interfaces will probably require the same so I thought I'd add some in a common place. This seems like the best home.
