### PR TITLE
lets bijection-util be distributed

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -219,9 +219,9 @@ object BijectionBuild extends Build {
   ).settings(
     name := "bijection-util",
     previousArtifact := youngestForwardCompatible("util"),
-    osgiExportAll("com.twitter.bijection.util"),
+    osgiExportAll("com.twitter.bijection.twitter_util"),
     libraryDependencies += "com.twitter" %% "util-core" % "6.2.0" cross CrossVersion.binaryMapped {
-      case "2.9.3" => "2.9.2" // TODO: hack because twitter hasn't built things agaisnt 2.9.3
+      case "2.9.3" => "2.9.2" // TODO: hack because twitter hasn't built things against 2.9.3
       case version if version startsWith "2.10" => "2.10" // TODO: hack because sbt is broken
       case x       => x
     }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.3
+sbt.version=0.12.4


### PR DESCRIPTION
## motivation

Try running `sbt 'project bijection-util' publish-local` and then unpacking the jar without this change.  Then try the same, except after this change has been applied.  Feel free to try wgetting [sonatype](https://oss.sonatype.org/content/groups/public/com/twitter/bijection-util_2.10/0.5.0/bijection-util_2.10-0.5.0.jar).
## implementation

there was a mismatch between osgiExportAll's concept of what the package name was, and what the package name actually was, which meant that none of the packages were being put into the jar.  They have been unified under twitter_util.
