### PR TITLE
Pin bijection-guava to jsr305 1.3.9.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -180,9 +180,10 @@ object BijectionBuild extends Build {
   lazy val bijectionGuava = module("guava").settings(
     osgiExportAll("com.twitter.bijection.guava"),
     libraryDependencies ++= Seq(
-      // This dependency is required due to a bug with guava 13.0, detailed here:
+      // This dependency is required because scalac needs access to all java
+      // runtime annotations even though javac does not as detailed here:
       // http://code.google.com/p/guava-libraries/issues/detail?id=1095
-      "com.google.code.findbugs" % "jsr305" % "1.3.+",
+      "com.google.code.findbugs" % "jsr305" % "1.3.9",
       "com.google.guava" % "guava" % "14.0"
     )
   ).dependsOn(bijectionCore % "test->test;compile->compile")


### PR DESCRIPTION
The bijection-guava module works around guava only requiring jsr305 in
provided scope yet scalac needing all java annotations at compile time
by adding an explicit dep on jsr305.  It was using a valid ivy
revision string with a trailing +, ie: '1.3.+' - and this works fine
for sbt / ivy; however make-pom does not attempt to map ivy version
numbers to valid pom version numbers and a trailing + is treated as a
literal and not a ranged version by maven / pom consumers [1]. This
work-around just pins jsr305 to 1.3.9 which is what guava 14 asks for
(in provided scope) in its own pom.  Another valid approach is to use
'[1.3,)' as the version which is valid in ivy.xml, sbt and pom.xml,
but fwict the original use of '1.3.+' was just copypasta from this bug
report: http://code.google.com/p/guava-libraries/issues/detail?id=1095

[1] https://github.com/sbt/sbt/blob/b7c50d42698f8309c76ed5fd0efbb3ef61ee601e/ivy/src/main/scala/sbt/MakePom.scala
