### PR TITLE
Update build publishTo to be consistent with scalding

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -53,12 +53,13 @@ object BijectionBuild extends Build {
 
     pomIncludeRepository := { x => false },
 
-    publishTo <<= version { (v: String) =>
-      val nexus = "https://oss.sonatype.org/"
-      if (v.trim.endsWith("SNAPSHOT"))
-        Some("sonatype-snapshots" at nexus + "content/repositories/snapshots")
-      else
-        Some("sonatype-releases-upload"  at nexus + "service/local/staging/deploy/maven2")
+    publishTo <<= version { v =>
+      Some(
+        if (v.trim.endsWith("SNAPSHOT"))
+          Opts.resolver.sonatypeSnapshots
+        else
+          Opts.resolver.sonatypeStaging
+      )
     },
 
     pomExtra := (


### PR DESCRIPTION
This uses the same method to get the resolver locations as scalding, with the benefit of not being hardcoded
