### PR TITLE
Add compression support to bijection-avro

### DIFF
--- a/bijection-avro/src/test/scala/com/twitter/bijection/avro/GenericAvroCodecsSpecification.scala
+++ b/bijection-avro/src/test/scala/com/twitter/bijection/avro/GenericAvroCodecsSpecification.scala
@@ -61,6 +61,46 @@ object GenericAvroCodecsSpecification extends Specification with BaseProperties 
       attempt.get must_== testRecord
     }
 
+    "Round trip generic record using Generic Injection with Bzip2 compression" in {
+      implicit val genericInjection = GenericAvroCodecs.withBzip2Compression[GenericRecord](testSchema)
+      val testRecord = buildGenericAvroRecord(("2012-01-01", 1, 12))
+      val bytes = Injection[GenericRecord, Array[Byte]](testRecord)
+      val attempt = Injection.invert[GenericRecord, Array[Byte]](bytes)
+      attempt.get must_== testRecord
+    }
+
+    "Round trip generic record using Generic Injection with Deflate compression (default compression level)" in {
+      implicit val genericInjection = GenericAvroCodecs.withDeflateCompression[GenericRecord](testSchema)
+      val testRecord = buildGenericAvroRecord(("2012-01-01", 1, 12))
+      val bytes = Injection[GenericRecord, Array[Byte]](testRecord)
+      val attempt = Injection.invert[GenericRecord, Array[Byte]](bytes)
+      attempt.get must_== testRecord
+    }
+
+    "Round trip generic record using Generic Injection with Deflate compression (custom compression level)" in {
+      implicit val genericInjection = GenericAvroCodecs.withDeflateCompression[GenericRecord](testSchema, 9)
+      val testRecord = buildGenericAvroRecord(("2012-01-01", 1, 12))
+      val bytes = Injection[GenericRecord, Array[Byte]](testRecord)
+      val attempt = Injection.invert[GenericRecord, Array[Byte]](bytes)
+      attempt.get must_== testRecord
+    }
+
+    "Cannot create Generic Injection with Deflate compression if compression level is set too low" in {
+      GenericAvroCodecs.withDeflateCompression[FiscalRecord](testSchema, 0) must throwA[IllegalArgumentException]
+    }
+
+    "Cannot create Generic Injection with Deflate compression if compression level is set too high" in {
+      GenericAvroCodecs.withDeflateCompression[FiscalRecord](testSchema, 10) must throwA[IllegalArgumentException]
+    }
+
+    "Round trip generic record using Generic Injection with Snappy compression" in {
+      implicit val genericInjection = GenericAvroCodecs.withSnappyCompression[GenericRecord](testSchema)
+      val testRecord = buildGenericAvroRecord(("2012-01-01", 1, 12))
+      val bytes = Injection[GenericRecord, Array[Byte]](testRecord)
+      val attempt = Injection.invert[GenericRecord, Array[Byte]](bytes)
+      attempt.get must_== testRecord
+    }
+
     "Round trip generic record using Binary Injection" in {
       implicit val genericBinaryInjection = GenericAvroCodecs.toBinary[GenericRecord](testSchema)
       val testRecord = buildGenericAvroRecord(("2012-01-01", 1, 12))

--- a/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecsSpecification.scala
+++ b/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecsSpecification.scala
@@ -46,6 +46,46 @@ object SpecificAvroCodecsSpecification extends Specification with BaseProperties
       attempt.get must_== testRecord
     }
 
+    "Round trip specific record using Specific Injection with Bzip2 compression" in {
+      implicit val specificInjection = SpecificAvroCodecs.withBzip2Compression[FiscalRecord]
+      val testRecord = buildSpecificAvroRecord(("2012-01-01", 1, 12))
+      val bytes = Injection[FiscalRecord, Array[Byte]](testRecord)
+      val attempt = Injection.invert[FiscalRecord, Array[Byte]](bytes)
+      attempt.get must_== testRecord
+    }
+
+    "Round trip specific record using Specific Injection with Deflate compression (default compression level)" in {
+      implicit val specificInjection = SpecificAvroCodecs.withDeflateCompression[FiscalRecord]
+      val testRecord = buildSpecificAvroRecord(("2012-01-01", 1, 12))
+      val bytes = Injection[FiscalRecord, Array[Byte]](testRecord)
+      val attempt = Injection.invert[FiscalRecord, Array[Byte]](bytes)
+      attempt.get must_== testRecord
+    }
+
+    "Round trip specific record using Specific Injection with Deflate compression (custom compression level)" in {
+      implicit val specificInjection = SpecificAvroCodecs.withDeflateCompression[FiscalRecord](9)
+      val testRecord = buildSpecificAvroRecord(("2012-01-01", 1, 12))
+      val bytes = Injection[FiscalRecord, Array[Byte]](testRecord)
+      val attempt = Injection.invert[FiscalRecord, Array[Byte]](bytes)
+      attempt.get must_== testRecord
+    }
+
+    "Cannot create Specific Injection with Deflate compression if compression level is set too low" in {
+      SpecificAvroCodecs.withDeflateCompression[FiscalRecord](0) must throwA[IllegalArgumentException]
+    }
+
+    "Cannot create Specific Injection with Deflate compression if compression level is set too high" in {
+      SpecificAvroCodecs.withDeflateCompression[FiscalRecord](10) must throwA[IllegalArgumentException]
+    }
+
+    "Round trip specific record using Specific Injection with Snappy compression" in {
+      implicit val specificInjection = SpecificAvroCodecs.withSnappyCompression[FiscalRecord]
+      val testRecord = buildSpecificAvroRecord(("2012-01-01", 1, 12))
+      val bytes = Injection[FiscalRecord, Array[Byte]](testRecord)
+      val attempt = Injection.invert[FiscalRecord, Array[Byte]](bytes)
+      attempt.get must_== testRecord
+    }
+
     "Round trip specific record using Binary Injection" in {
       implicit val specificBinaryInjection = SpecificAvroCodecs.toBinary[FiscalRecord]
       val testRecord = buildSpecificAvroRecord(("2012-01-01", 1, 12))


### PR DESCRIPTION
This API enhancement is backwards compatible.

We add `withCompression()` factory methods to `SpecificAvroCodecs` and `GenericAvroCodecs`, and also add the following three convenience methods:
- `withBzip2Compression`
- `withDeflateCompression`
- `withSnappyCompression`

(I did not add a `withXzCompression` method as this codec was apparently introduced in Avro 1.7.6, and Bijection is currently still using the older 1.7.5 version.)

**Usage examples**

``` scala
// Encode data, no compression (already supported in bijection-avro)
implicit val specificInjection = SpecificAvroCodecs[FiscalRecord]

// Encode data, with Snappy compression (new feature)
implicit val specificInjection = SpecificAvroCodecs.withSnappyCompression[FiscalRecord]
```

Compression in Avro is transparent to readers of the data, which means that there is no change needed on the decoding side of things.

**No compression support added to `toBinary` methods**

Please note that I did not add corresponding compression support to `GenericAvroCodecs.toBinary` and `SpecificAvroCodecs.toBinary` (i.e. the Injection variants that _do not_ embed the Avro schema into the encoded binary data).  This is because Avro's API provides [compression only at the file container level (i.e. block compression)](http://grokbase.com/t/avro/user/1349vbdew2/enabling-compression).  In other words, without using Avro's `DataFileWriter` class -- which is what Bijection does for `apply` but not for `toBinary` -- we cannot set a compression codec.  We can try to work around that limitation, but this would turn `toBinary` into a renamed `apply` method, and it would make the code inconsistent because suddenly `toBinary` would embed the Avro schema into each encoded record (which it does not do in the current code, and which is IMHO the core semantic difference between `toBinary` and `apply`).
