### PR TITLE
Start work on primitive, caseclass restrictions

### DIFF
--- a/bijection-macros/src/main/scala/com/twitter/bijection/macros/MacroAnnotations.scala
+++ b/bijection-macros/src/main/scala/com/twitter/bijection/macros/MacroAnnotations.scala
@@ -12,6 +12,12 @@ object IsCaseClass {
 
 trait IsCaseClass[T]
 
+object IsPrimitiveCaseClass {
+  implicit def isPrimitiveCaseClass[T]: IsPrimitiveCaseClass[T] = macro IsPrimitiveCaseClassImpl.isPrimitiveCaseClassImpl[T]
+}
+
+trait IsPrimitiveCaseClass[T] extends IsCaseClass[T]
+
 /**
  * This is a tag trait to allow macros to signal, in a uniform way, that a piece of code was generated.
  */

--- a/bijection-macros/src/main/scala/com/twitter/bijection/macros/impl/CaseClassToMap.scala
+++ b/bijection-macros/src/main/scala/com/twitter/bijection/macros/impl/CaseClassToMap.scala
@@ -39,12 +39,12 @@ private[bijection] object CaseClassToMap {
         val returnType = m.returnType
         val accStr = m.name.toTermName.toString
         returnType match {
-          case tpe if recursivelyApply && IsCaseClassImpl.isCaseClassType(c)(tpe) =>
+          case innerTpe if recursivelyApply && IsCaseClassImpl.isCaseClassType(c)(innerTpe) =>
             val conv = newTermName("c2m_" + idx)
             (q"""$conv.invert(m($accStr).asInstanceOf[_root_.scala.collection.immutable.Map[String, Any]]).get""",
               q"""($accStr, $conv(t.$m))""",
-              Some(q"""val $conv = implicitly[_root_.com.twitter.bijection.Injection[$tpe, _root_.scala.collection.immutable.Map[String, Any]]]""")) //TODO cache these
-          case tpe =>
+              Some(q"""val $conv = implicitly[_root_.com.twitter.bijection.Injection[$innerTpe, _root_.scala.collection.immutable.Map[String, Any]]]""")) //TODO cache these
+          case innerTpe =>
             (q"""m($accStr).asInstanceOf[$returnType]""",
               q"""($accStr, t.$m)""",
               None)

--- a/bijection-macros/src/main/scala/com/twitter/bijection/macros/impl/FieldDescriptor.scala
+++ b/bijection-macros/src/main/scala/com/twitter/bijection/macros/impl/FieldDescriptor.scala
@@ -1,0 +1,25 @@
+package com.twitter.bijection.macros.impl
+
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+import scala.reflect.runtime.universe._
+import scala.util.{ Try => BasicTry }
+
+case class FieldDescriptor[C <: Context](c: C, indx: Int, name: String, fType: C#Type)
+
+object FieldDescriptor {
+  def extractFromTpe[T](c: Context)(implicit T: c.WeakTypeTag[T]): Iterable[FieldDescriptor[Context]] = {
+    import c.universe._
+
+    T.tpe
+      .declarations
+      .collect { case m: MethodSymbol if m.isCaseAccessor => m }
+      .zipWithIndex
+      .map {
+        case (m, idx) =>
+          val fieldName = m.name.toTermName.toString
+          val fieldType = m.returnType
+          FieldDescriptor(c, idx, fieldName, fieldType)
+      }
+  }
+}

--- a/bijection-macros/src/main/scala/com/twitter/bijection/macros/impl/IsPrimitiveCaseClass.scala
+++ b/bijection-macros/src/main/scala/com/twitter/bijection/macros/impl/IsPrimitiveCaseClass.scala
@@ -1,0 +1,45 @@
+package com.twitter.bijection.macros.impl
+
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+import scala.reflect.runtime.universe._
+import scala.util.{ Try => BasicTry }
+
+import com.twitter.bijection.macros.{ IsPrimitiveCaseClass, MacroGenerated }
+
+object IsPrimitiveCaseClassImpl {
+
+  private[this] val primitiveTypes = List(
+    "Boolean",
+    "Double",
+    "Float",
+    "Long",
+    "Int",
+    "Short",
+    "Byte",
+    "Boolean",
+    "Char")
+
+  def isPrimitiveCaseClassImpl[T](c: Context)(implicit T: c.WeakTypeTag[T]): c.Expr[IsPrimitiveCaseClass[T]] = {
+    import c.universe._
+    if (IsCaseClassImpl.isCaseClassType(c)(T.tpe)) {
+      if (T.tpe.typeConstructor.takesTypeArgs) {
+        c.abort(c.enclosingPosition, "Case class with type parameters currently not supported")
+      } else if (!hasOnlyPrimitiveTypes[T](c)) {
+        c.abort(c.enclosingPosition, "Non primitive case class")
+      } else {
+        c.Expr[IsPrimitiveCaseClass[T]](q"""_root_.com.twitter.bijection.macros.impl.MacroGeneratedIsPrimitiveCaseClass[$T]()""")
+      }
+    } else {
+      c.abort(c.enclosingPosition, "Type parameter is not a case class")
+    }
+  }
+
+  def hasOnlyPrimitiveTypes[T](c: Context)(implicit T: c.WeakTypeTag[T]): Boolean =
+    FieldDescriptor.extractFromTpe[T](c).forall { t =>
+      primitiveTypes.contains(t.fType.toString)
+    }
+
+}
+
+case class MacroGeneratedIsPrimitiveCaseClass[T]() extends IsPrimitiveCaseClass[T] with MacroGenerated


### PR DESCRIPTION
Still a WIP:

Needs a test or two.

But it works, it only passes on case classes whose fields are all primitives. 

Use case:

Scalding JDBC

Aiming for ultimate usage to be along the lines of

`MysqlJdbcSource[MyType](connectionProps) extends TypedSink[MyType]`

So auto generate how to do whatever column mappings needed from the type, so restrictions on its shape are probably a reasonable first stab.