### PR TITLE
FIX: gzip Bijection resource leak.

### DIFF
--- a/bijection-core/src/main/scala/com/twitter/bijection/BinaryBijections.scala
+++ b/bijection-core/src/main/scala/com/twitter/bijection/BinaryBijections.scala
@@ -81,12 +81,14 @@ trait BinaryBijections extends StringBijections {
         val baos = new ByteArrayOutputStream
         val gos = new GZIPOutputStream(baos)
         gos.write(bytes)
-        gos.finish()
+        gos.close()
         GZippedBytes(baos.toByteArray)
       }
       override def invert(gz: GZippedBytes) = {
         val baos = new ByteArrayOutputStream
-        copy(new GZIPInputStream(new ByteArrayInputStream(gz.bytes)), baos)
+        val is = new GZIPInputStream(new ByteArrayInputStream(gz.bytes))
+        copy(is, baos)
+        is.close()
         baos.toByteArray
       }
     }


### PR DESCRIPTION
GZIPOutputStream#finish() does not relinquish all resources.

Specifically the Deflater instance used internally will release resources when end() called which only happens on close() or when finalize() is invoked by the garbage collector.

Thus, the use of finish() without close() relies on finalizers to cleanup resources which is a Bad Thing(tm).

The same logic was applied to the reverse Bijection.