### PR TITLE
Specialize the TBinaryProtocol read path up to ~2x speedups

### DIFF
--- a/bijection-finagle-mysql/src/test/scala/com/twitter/bijection/finagle_mysql/MySqlConversionLaws.scala
+++ b/bijection-finagle-mysql/src/test/scala/com/twitter/bijection/finagle_mysql/MySqlConversionLaws.scala
@@ -97,10 +97,11 @@ class MySqlConversionLaws extends CheckProperties with BaseProperties {
     isInjection[NullValue.type, Option[String]]
   }
   property("Timestamp") {
-    /** Custom equivalence typeclass for RawValue
-      * This is here to compare two RawValues generated from Timestamps.
-      * Because they contain byte arrays, just =='ing them does not work as expected.
-      */
+    /**
+     * Custom equivalence typeclass for RawValue
+     * This is here to compare two RawValues generated from Timestamps.
+     * Because they contain byte arrays, just =='ing them does not work as expected.
+     */
     implicit val valueEquiv = new scala.math.Equiv[Value] {
       override def equiv(a: Value, b: Value) = (a, b) match {
         case (RawValue(Type.Timestamp, Charset.Binary, true, bytes1),

--- a/bijection-scrooge/src/main/scala/com/twitter/bijection/scrooge/ScroogeCodecs.scala
+++ b/bijection-scrooge/src/main/scala/com/twitter/bijection/scrooge/ScroogeCodecs.scala
@@ -18,6 +18,7 @@ package com.twitter.bijection.scrooge
 
 import com.twitter.bijection.{ Bijection, Injection }
 import com.twitter.bijection.Inversion.attempt
+import com.twitter.bijection.macros.Macros
 import com.twitter.scrooge._
 import org.apache.thrift.protocol.TJSONProtocol
 
@@ -44,7 +45,7 @@ class BinaryScalaCodec[T <: ThriftStruct](c: ThriftStructCodec[T])
   }
 
   override def apply(item: T) = thriftStructSerializer.toBytes(item)
-  override def invert(bytes: Array[Byte]) = attempt(bytes){ bytes =>
+  override def invert(bytes: Array[Byte]) = Macros.fastAttempt(bytes){
     c.decode(TArrayBinaryProtocol(TArrayByteTransport(bytes)))
   }
 }

--- a/bijection-thrift/src/main/scala/com/twitter/bijection/thrift/TArrayBinaryProtocol.scala
+++ b/bijection-thrift/src/main/scala/com/twitter/bijection/thrift/TArrayBinaryProtocol.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.twitter.bijection.thrift
+
+import java.io.UnsupportedEncodingException
+import java.nio.ByteBuffer
+
+import org.apache.thrift.protocol._
+import org.apache.thrift.TException
+import org.apache.thrift.transport.TTransport
+
+/**
+ * Binary protocol implementation for thrift.
+ *
+ */
+object TArrayBinaryProtocol {
+  private val ANONYMOUS_STRUCT: TStruct = new TStruct()
+}
+
+case class TArrayBinaryProtocol(transport: TArrayByteTransport) extends TProtocol(transport) {
+  import TArrayBinaryProtocol._
+
+  def readMessageBegin(): TMessage = {
+    sys.error("Protocol for serialized structures only")
+  }
+
+  def writeBinary(x$1: java.nio.ByteBuffer): Unit = ???
+  def writeBool(x$1: Boolean): Unit = ???
+  def writeByte(x$1: Byte): Unit = ???
+  def writeDouble(x$1: Double): Unit = ???
+  def writeFieldBegin(x$1: org.apache.thrift.protocol.TField): Unit = ???
+  def writeFieldEnd(): Unit = ???
+  def writeFieldStop(): Unit = ???
+  def writeI16(x$1: Short): Unit = ???
+  def writeI32(x$1: Int): Unit = ???
+  def writeI64(x$1: Long): Unit = ???
+  def writeListBegin(x$1: org.apache.thrift.protocol.TList): Unit = ???
+  def writeListEnd(): Unit = ???
+  def writeMapBegin(x$1: org.apache.thrift.protocol.TMap): Unit = ???
+  def writeMapEnd(): Unit = ???
+  def writeMessageBegin(x$1: org.apache.thrift.protocol.TMessage): Unit = ???
+  def writeMessageEnd(): Unit = ???
+  def writeSetBegin(x$1: org.apache.thrift.protocol.TSet): Unit = ???
+  def writeSetEnd(): Unit = ???
+  def writeString(x$1: String): Unit = ???
+  def writeStructBegin(x$1: org.apache.thrift.protocol.TStruct): Unit = ???
+  def writeStructEnd(): Unit = ???
+
+  def readMessageEnd() {}
+
+  override final def readStructBegin: TStruct = ANONYMOUS_STRUCT
+
+  override final def readStructEnd: Unit = {}
+
+  override final def readFieldBegin: TField = {
+    val tpe: Byte = readByte
+    val id: Short = if (tpe == TType.STOP) 0 else readI16
+    new TField("", tpe, id)
+  }
+
+  override final def readFieldEnd(): Unit = {}
+
+  override final def readMapBegin: TMap = new TMap(readByte, readByte, readI32)
+
+  override final def readMapEnd(): Unit = {}
+
+  override final def readListBegin: TList = new TList(readByte, readI32)
+
+  override final def readListEnd(): Unit = {}
+
+  override final def readSetBegin: TSet = new TSet(readByte, readI32)
+
+  override final def readSetEnd(): Unit = {}
+
+  override final def readBool: Boolean = readByte == 1
+
+  @inline
+  private[this] final def advance(by: Int) {
+    transport.bufferPos = transport.bufferPos + by
+  }
+
+  @inline
+  def readByte: Byte = {
+    val r: Byte = transport.buf(transport.bufferPos)
+    advance(1)
+    r
+  }
+
+  @inline
+  def readI32: Int = {
+    val off = transport.bufferPos
+    advance(4)
+    ((transport.buf(off) & 0xff) << 24) |
+      ((transport.buf(off + 1) & 0xff) << 16) |
+      ((transport.buf(off + 2) & 0xff) << 8) |
+      ((transport.buf(off + 3) & 0xff))
+  }
+
+  @inline
+  def readI16: Short = {
+    val off = transport.bufferPos
+    advance(2)
+    (((transport.buf(off) & 0xff) << 8) | ((transport.buf(off + 1) & 0xff))).toShort
+  }
+
+  @inline
+  def readI64: Long = {
+    val off = transport.bufferPos
+    advance(8)
+    ((transport.buf(off) & 0xffL) << 56) |
+      ((transport.buf(off + 1) & 0xffL) << 48) |
+      ((transport.buf(off + 2) & 0xffL) << 40) |
+      ((transport.buf(off + 3) & 0xffL) << 32) |
+      ((transport.buf(off + 4) & 0xffL) << 24) |
+      ((transport.buf(off + 5) & 0xffL) << 16) |
+      ((transport.buf(off + 6) & 0xffL) << 8) |
+      ((transport.buf(off + 7) & 0xffL))
+  }
+
+  def readDouble: Double =
+    java.lang.Double.longBitsToDouble(readI64)
+
+  def readString: String =
+    try {
+      val size = readI32
+      val s = new String(transport.buf, transport.bufferPos, size, "UTF-8")
+      advance(size)
+      s
+    } catch {
+      case e: UnsupportedEncodingException =>
+        throw new TException("JVM DOES NOT SUPPORT UTF-8")
+    }
+
+  def readBinary: ByteBuffer = {
+    val size = readI32
+    val bb = ByteBuffer.wrap(transport.buf, transport.bufferPos, size)
+    advance(size)
+    bb
+  }
+
+}

--- a/bijection-thrift/src/main/scala/com/twitter/bijection/thrift/TArrayByteTransport.scala
+++ b/bijection-thrift/src/main/scala/com/twitter/bijection/thrift/TArrayByteTransport.scala
@@ -1,0 +1,40 @@
+package com.twitter.bijection.thrift
+
+import org.apache.thrift.protocol._
+import org.apache.thrift.TException
+import org.apache.thrift.transport.TTransport
+
+case class TArrayByteTransport(buf: Array[Byte]) extends TTransport {
+  private[thrift] final var bufferPos = 0
+  private[this] final val bufferSiz_ = buf.size
+
+  @inline
+  final def bufferSiz = bufferSiz_
+
+  override final def isOpen: Boolean = bufferPos < bufferSiz_
+
+  override final def open() {}
+
+  override final def close() {}
+
+  override final def readAll(destBuf: Array[Byte], off: Int, len: Int): Int =
+    read(destBuf, off, len)
+
+  override final def read(destBuf: Array[Byte], destOffset: Int, len: Int): Int = {
+    System.arraycopy(buf, bufferPos, destBuf, destOffset, len)
+    bufferPos = bufferPos + len
+    len
+  }
+
+  override final def getBufferPosition: Int = bufferPos
+  override final def getBytesRemainingInBuffer: Int = bufferSiz_ - bufferPos
+  override final def getBuffer: Array[Byte] = buf
+
+  override final def write(buf: Array[Byte], off: Int, len: Int): Unit = {
+    sys.error("not implemented")
+  }
+
+  override final def consumeBuffer(len: Int): Unit = {
+    bufferPos = bufferPos + len
+  }
+}

--- a/bijection-thrift/src/main/scala/com/twitter/bijection/thrift/ThriftCodecs.scala
+++ b/bijection-thrift/src/main/scala/com/twitter/bijection/thrift/ThriftCodecs.scala
@@ -2,6 +2,7 @@ package com.twitter.bijection.thrift
 
 import com.twitter.bijection.{ Bijection, Conversion, Injection, InversionFailure, StringCodec }
 import com.twitter.bijection.Inversion.attempt
+import com.twitter.bijection.macros.Macros
 import java.io.{ ByteArrayInputStream, ByteArrayOutputStream }
 import org.apache.thrift.{ TBase, TEnum }
 import org.apache.thrift.protocol.{
@@ -74,7 +75,7 @@ class BinaryThriftCodec[T <: TBase[_, _]](klass: Class[T])
     item.write(factory.getProtocol(new TIOStreamTransport(baos)))
     baos.toByteArray
   }
-  override def invert(bytes: Array[Byte]) = attempt(bytes) { bytes =>
+  override def invert(bytes: Array[Byte]) = Macros.fastAttempt(bytes){
     val obj = prototype.deepCopy
     obj.read(TArrayBinaryProtocol(TArrayByteTransport(bytes)))
     obj.asInstanceOf[T]

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -218,7 +218,7 @@ object BijectionBuild extends Build {
       "com.twitter" %% "util-core" % "6.24.0",
       "com.twitter" %% "finagle-core" % "6.25.0" % "test"
     )
-  ).dependsOn(bijectionCore % "test->test;compile->compile")
+  ).dependsOn(bijectionCore % "test->test;compile->compile", bijectionThrift)
 
   lazy val bijectionJson = module("json").settings(
     osgiExportAll("com.twitter.bijection.json"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -197,7 +197,7 @@ object BijectionBuild extends Build {
       "org.apache.thrift" % "libthrift" % "0.6.1" exclude("junit", "junit"),
       jsonParser
     )
-  ).dependsOn(bijectionCore % "test->test;compile->compile")
+  ).dependsOn(bijectionCore % "test->test;compile->compile", bijectionMacros)
 
   lazy val bijectionGuava = module("guava").settings(
     osgiExportAll("com.twitter.bijection.guava"),
@@ -218,7 +218,7 @@ object BijectionBuild extends Build {
       "com.twitter" %% "util-core" % "6.24.0",
       "com.twitter" %% "finagle-core" % "6.25.0" % "test"
     )
-  ).dependsOn(bijectionCore % "test->test;compile->compile", bijectionThrift)
+  ).dependsOn(bijectionCore % "test->test;compile->compile", bijectionMacros, bijectionThrift)
 
   lazy val bijectionJson = module("json").settings(
     osgiExportAll("com.twitter.bijection.json"),


### PR DESCRIPTION
![bijectiondeserwin](https://cloud.githubusercontent.com/assets/446652/7950866/4ddd0ecc-0955-11e5-9dd5-212d7da87d3b.png)

Can see the prior delta in the posted image. The macro stays below but the others that do full deserialization converge with this change.
