### PR TITLE
Add toBinaryWithSchema in order to support Avro generated Scala case classes

### DIFF
--- a/bijection-avro/src/main/scala/com/twitter/bijection/avro/AvroCodecs.scala
+++ b/bijection-avro/src/main/scala/com/twitter/bijection/avro/AvroCodecs.scala
@@ -109,6 +109,18 @@ object SpecificAvroCodecs {
   }
 
   /**
+   * Returns Injection capable of serializing and deserializing a compiled avro record using org.apache.avro.io.BinaryEncoder.
+   * Accepts a schema to support generated Scala case classes.
+   * @tparam T compiled Avro record
+   * @return Injection
+   */
+  def toBinaryWithSchema[T <: SpecificRecordBase: ClassTag](schema: Schema): Injection[T, Array[Byte]] = {
+    val writer = new SpecificDatumWriter[T](schema)
+    val reader = new SpecificDatumReader[T](schema)
+    new BinaryAvroCodec[T](writer, reader)
+  }
+
+  /**
    * Returns Injection capable of serializing and deserializing a generic avro record using org.apache.avro.io.JsonEncoder to a
    * UTF-8 String
    * @tparam T compiled Avro record

--- a/bijection-avro/src/main/scala/com/twitter/bijection/avro/AvroCodecs.scala
+++ b/bijection-avro/src/main/scala/com/twitter/bijection/avro/AvroCodecs.scala
@@ -110,12 +110,13 @@ object SpecificAvroCodecs {
 
   /**
    * Returns Injection capable of serializing and deserializing a compiled avro record using org.apache.avro.io.BinaryEncoder.
-   * Accepts a schema to support generated Scala case classes. This is not completely typesafe and will fail at runtime
-   * when you pass in the wrong schema.
+   * Fetches the schema from the specified class in order to be compatible with generated Scala classes.
    * @tparam T compiled Avro record
    * @return Injection
    */
-  def toBinaryWithSchema[T <: SpecificRecordBase](schema: Schema): Injection[T, Array[Byte]] = {
+  def toBinaryWithSchema[T <: SpecificRecordBase: ClassTag]: Injection[T, Array[Byte]] = {
+    val record = classTag[T].runtimeClass.newInstance().asInstanceOf[T]
+    val schema = record.getSchema
     val writer = new SpecificDatumWriter[T](schema)
     val reader = new SpecificDatumReader[T](schema)
     new BinaryAvroCodec[T](writer, reader)

--- a/bijection-avro/src/main/scala/com/twitter/bijection/avro/AvroCodecs.scala
+++ b/bijection-avro/src/main/scala/com/twitter/bijection/avro/AvroCodecs.scala
@@ -110,11 +110,12 @@ object SpecificAvroCodecs {
 
   /**
    * Returns Injection capable of serializing and deserializing a compiled avro record using org.apache.avro.io.BinaryEncoder.
-   * Accepts a schema to support generated Scala case classes.
+   * Accepts a schema to support generated Scala case classes. This is not completely typesafe and will fail at runtime
+   * when you pass in the wrong schema.
    * @tparam T compiled Avro record
    * @return Injection
    */
-  def toBinaryWithSchema[T <: SpecificRecordBase: ClassTag](schema: Schema): Injection[T, Array[Byte]] = {
+  def toBinaryWithSchema[T <: SpecificRecordBase](schema: Schema): Injection[T, Array[Byte]] = {
     val writer = new SpecificDatumWriter[T](schema)
     val reader = new SpecificDatumReader[T](schema)
     new BinaryAvroCodec[T](writer, reader)

--- a/bijection-avro/src/test/java/avro/FiscalRecordScala.scala
+++ b/bijection-avro/src/test/java/avro/FiscalRecordScala.scala
@@ -1,0 +1,49 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package avro
+
+case class FiscalRecordScala(var calendarDate: String, var fiscalWeek: Option[Int], var fiscalYear: Option[Int]) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this("", Some(1), Some(1))
+  def get(field: Int): AnyRef = {
+    field match {
+      case pos if pos == 0 => {
+        calendarDate
+      }.asInstanceOf[AnyRef]
+      case pos if pos == 1 => {
+        fiscalWeek match {
+          case Some(x) => x
+          case None => null
+        }
+      }.asInstanceOf[AnyRef]
+      case pos if pos == 2 => {
+        fiscalYear match {
+          case Some(x) => x
+          case None => null
+        }
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field: Int, value: Any): Unit = {
+    field match {
+      case pos if pos == 0 => this.calendarDate = {
+        value match {
+          case (value: org.apache.avro.util.Utf8) => value.toString
+          case _ => value
+        }
+      }.asInstanceOf[String]
+      case pos if pos == 1 => this.fiscalWeek = {
+        Option(value)
+      }.asInstanceOf[Option[Int]]
+      case pos if pos == 2 => this.fiscalYear = {
+        Option(value)
+      }.asInstanceOf[Option[Int]]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = FiscalRecordScala.SCHEMA$
+}
+
+object FiscalRecordScala {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"FiscalRecordScala\",\"namespace\":\"avro\",\"fields\":[{\"name\":\"calendarDate\",\"type\":\"string\"},{\"name\":\"fiscalWeek\",\"type\":[\"int\",\"null\"]},{\"name\":\"fiscalYear\",\"type\":[\"int\",\"null\"]}]}")
+}

--- a/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecLaws.scala
+++ b/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecLaws.scala
@@ -64,7 +64,7 @@ class SpecificAvroCodecLaws extends CheckProperties with BaseProperties {
   }
 
   property("round trips Specific Record -> Array[Byte] using Binary Encoder/Decoder with schema") {
-    roundTripsSpecificRecord(SpecificAvroCodecs.toBinaryWithSchema[FiscalRecord](testSchema))
+    roundTripsSpecificRecord(SpecificAvroCodecs.toBinaryWithSchema[FiscalRecord])
   }
 
   property("round trips Specific Record -> String using Json Encoder/Decoder") {

--- a/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecLaws.scala
+++ b/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecLaws.scala
@@ -63,6 +63,10 @@ class SpecificAvroCodecLaws extends CheckProperties with BaseProperties {
     roundTripsSpecificRecord(SpecificAvroCodecs.toBinary[FiscalRecord])
   }
 
+  property("round trips Specific Record -> Array[Byte] using Binary Encoder/Decoder with schema") {
+    roundTripsSpecificRecord(SpecificAvroCodecs.toBinaryWithSchema[FiscalRecord](testSchema))
+  }
+
   property("round trips Specific Record -> String using Json Encoder/Decoder") {
     roundTripsSpecificRecordToJson(SpecificAvroCodecs.toJson[FiscalRecord](testSchema))
   }

--- a/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecsSpecification.scala
+++ b/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecsSpecification.scala
@@ -95,21 +95,11 @@ class SpecificAvroCodecsSpecification extends WordSpec with Matchers with BasePr
     }
 
     "Round trip specific record using Binary Injection With Schema for Scala case classes" in {
-      implicit val specificBinaryInjection = SpecificAvroCodecs.toBinaryWithSchema[FiscalRecordScala](FiscalRecordScala.SCHEMA$)
+      implicit val specificBinaryInjection = SpecificAvroCodecs.toBinaryWithSchema[FiscalRecordScala]
       val testRecord = FiscalRecordScala("2012-01-01", Some(1), Some(12))
       val bytes = Injection[FiscalRecordScala, Array[Byte]](testRecord)
       val attempt = Injection.invert[FiscalRecordScala, Array[Byte]](bytes)
       assert(attempt.get == testRecord)
-    }
-
-    "Binary with schema will fail with exception when passing in wrong schema" in {
-      val wrongSchema = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"WrongRecord\",\"namespace\":\"avro\",\"fields\":[{\"name\":\"date\",\"type\":\"string\"}]}")
-      implicit val specificBinaryInjection = SpecificAvroCodecs.toBinaryWithSchema[FiscalRecordScala](wrongSchema)
-      val testRecord = FiscalRecordScala("2012-01-01", Some(1), Some(12))
-      val bytes = Injection[FiscalRecordScala, Array[Byte]](testRecord)
-      val attempt = Injection.invert[FiscalRecordScala, Array[Byte]](bytes)
-
-      assert(trap(attempt.get).isInstanceOf[ClassCastException])
     }
 
     "Round trip specific record using Json Injection" in {

--- a/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecsSpecification.scala
+++ b/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecsSpecification.scala
@@ -3,7 +3,7 @@ package com.twitter.bijection.avro
 import org.scalatest._
 import com.twitter.bijection.{ Injection, BaseProperties }
 import org.apache.avro.Schema
-import avro.FiscalRecord
+import avro.{ FiscalRecordScala, FiscalRecord }
 
 /**
  * @author Muhammad Ashraf
@@ -91,6 +91,14 @@ class SpecificAvroCodecsSpecification extends WordSpec with Matchers with BasePr
       val testRecord = buildSpecificAvroRecord(("2012-01-01", 1, 12))
       val bytes = Injection[FiscalRecord, Array[Byte]](testRecord)
       val attempt = Injection.invert[FiscalRecord, Array[Byte]](bytes)
+      assert(attempt.get == testRecord)
+    }
+
+    "Round trip specific record using Binary Injection With Schema for Scala case classes" in {
+      implicit val specificBinaryInjection = SpecificAvroCodecs.toBinaryWithSchema[FiscalRecordScala](FiscalRecordScala.SCHEMA$)
+      val testRecord = FiscalRecordScala("2012-01-01", Some(1), Some(12))
+      val bytes = Injection[FiscalRecordScala, Array[Byte]](testRecord)
+      val attempt = Injection.invert[FiscalRecordScala, Array[Byte]](bytes)
       assert(attempt.get == testRecord)
     }
 

--- a/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecsSpecification.scala
+++ b/bijection-avro/src/test/scala/com/twitter/bijection/avro/SpecificAvroCodecsSpecification.scala
@@ -102,6 +102,16 @@ class SpecificAvroCodecsSpecification extends WordSpec with Matchers with BasePr
       assert(attempt.get == testRecord)
     }
 
+    "Binary with schema will fail with exception when passing in wrong schema" in {
+      val wrongSchema = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"WrongRecord\",\"namespace\":\"avro\",\"fields\":[{\"name\":\"date\",\"type\":\"string\"}]}")
+      implicit val specificBinaryInjection = SpecificAvroCodecs.toBinaryWithSchema[FiscalRecordScala](wrongSchema)
+      val testRecord = FiscalRecordScala("2012-01-01", Some(1), Some(12))
+      val bytes = Injection[FiscalRecordScala, Array[Byte]](testRecord)
+      val attempt = Injection.invert[FiscalRecordScala, Array[Byte]](bytes)
+
+      assert(trap(attempt.get).isInstanceOf[ClassCastException])
+    }
+
     "Round trip specific record using Json Injection" in {
       implicit val specificJsonInjection = SpecificAvroCodecs.toJson[FiscalRecord](testSchema)
       val testRecord = buildSpecificAvroRecord(("2012-01-01", 1, 12))


### PR DESCRIPTION
Add `toBinaryWithSchema` in order to support Avro generated Scala case classes.

Otherwise Scala classes are not recognized as specific records because they don't have a public field called `SCHEMA$`.