### PR TITLE
Mostly maintenance commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ Every artifact is published against Scala `"2.10"` and `"2.11"`. To pull in the 
 
 `bijection-core_2.10` or `bijection-core_2.11`
 
+## Chat
+[![Gitter](https://badges.gitter.im/twitter/bijection.svg)](https://gitter.im/twitter/bijection?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
 ## Authors
 
 * Oscar Boykin <http://twitter.com/posco>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -18,7 +18,7 @@ object BijectionBuild extends Build {
   val sharedSettings = Project.defaultSettings ++ osgiSettings ++ scalariformSettings ++ Seq(
     organization := "com.twitter",
 
-    crossScalaVersions := Seq("2.10.5", "2.11.5"),
+    crossScalaVersions := Seq("2.10.5", "2.11.7"),
 
     ScalariformKeys.preferences := formattingPreferences,
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.9

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,1 @@
-
-version in ThisBuild := "0.8.1"
+version in ThisBuild := "0.8.2-SNAPSHOT"


### PR DESCRIPTION
Kicks the version of sbt up to latest(some plugins have issues between the version that was here and latest...).

Bump the version to the next snapshot -- sbt has resolver issues if you leave the version with the published copy often now

And moved onto latest scala 2.11