### PR TITLE
Reduce the exposed type granularity down, maintains binary compat wit…

### DIFF
--- a/bijection-hbase/src/main/scala/com/twitter/bijection/hbase/HBaseInjections.scala
+++ b/bijection-hbase/src/main/scala/com/twitter/bijection/hbase/HBaseInjections.scala
@@ -56,7 +56,7 @@ object HBaseInjections {
    * ImmutableBytesWritable injections avoid copying when possible and use the
    * slice (offset and length) of the underlying byte array.
    */
-  implicit lazy val string2BytesWritableInj =
+  implicit lazy val string2BytesWritableInj: Injection[String, ImmutableBytesWritable] =
     new ImmutableBytesWritableInjection[String] {
       override def invert(b: ImmutableBytesWritable) =
         fastAttempt(b)(Bytes.toString(b.get, b.getOffset, b.getLength) match {
@@ -64,37 +64,37 @@ object HBaseInjections {
           case str => str
         })
     }
-  implicit lazy val int2BytesWritableInj =
+  implicit lazy val int2BytesWritableInj: Injection[Int, ImmutableBytesWritable] =
     new ImmutableBytesWritableInjection[Int] {
       override def invert(b: ImmutableBytesWritable) =
         fastAttempt(b)(Bytes.toInt(b.get, b.getOffset, b.getLength))
     }
-  implicit lazy val long2BytesWritableInj =
+  implicit lazy val long2BytesWritableInj: Injection[Long, ImmutableBytesWritable] =
     new ImmutableBytesWritableInjection[Long] {
       override def invert(b: ImmutableBytesWritable) =
         fastAttempt(b)(Bytes.toLong(b.get, b.getOffset, b.getLength))
     }
-  implicit lazy val double2BytesWritableInj =
+  implicit lazy val double2BytesWritableInj: Injection[Double, ImmutableBytesWritable] =
     new ImmutableBytesWritableInjection[Double] {
       override def invert(b: ImmutableBytesWritable) =
         fastAttempt(b)(Bytes.toDouble(b.get, b.getOffset))
     }
-  implicit lazy val float2BytesWritableInj =
+  implicit lazy val float2BytesWritableInj: Injection[Float, ImmutableBytesWritable] =
     new ImmutableBytesWritableInjection[Float] {
       override def invert(b: ImmutableBytesWritable) =
         fastAttempt(b)(Bytes.toFloat(b.get, b.getOffset))
     }
-  implicit lazy val short2BytesWritableInj =
+  implicit lazy val short2BytesWritableInj: Injection[Short, ImmutableBytesWritable] =
     new ImmutableBytesWritableInjection[Short] {
       override def invert(b: ImmutableBytesWritable) =
         fastAttempt(b)(Bytes.toShort(b.get, b.getOffset, b.getLength))
     }
-  implicit lazy val boolean2BytesWritableInj =
+  implicit lazy val boolean2BytesWritableInj: Injection[Boolean, ImmutableBytesWritable] =
     new ImmutableBytesWritableInjection[Boolean] {
       override def invert(b: ImmutableBytesWritable) =
         fastAttempt(b)(Bytes.toBoolean(b.copyBytes))
     }
-  implicit lazy val bigDecimal2BytesWritableInj =
+  implicit lazy val bigDecimal2BytesWritableInj: Injection[BigDecimal, ImmutableBytesWritable] =
     new ImmutableBytesWritableInjection[BigDecimal] {
       override def invert(b: ImmutableBytesWritable) =
         fastAttempt(b)(Bytes.toBigDecimal(b.get, b.getOffset, b.getLength))


### PR DESCRIPTION
…h last rls

Remaining binary incompatible changes between releases looks like:
```
[error]  * method fromBuilder(scala.collection.mutable.Builder,com.twitter.bijection.json.JsonNodeInjection)com.twitter.bijection.json.JsonNodeInjection in object com.twitter.bijection.json.JsonNodeInjection does not have a correspondent in new version
[error]    filter with: ProblemFilters.exclude[MissingMethodProblem]("com.twitter.bijection.json.JsonNodeInjection.fromBuilder")
[error]  * the type hierarchy of class com.twitter.bijection.scrooge.BinaryScalaCodec has changed in new version. Missing types {com.twitter.bijection.scrooge.ScalaCodec}
[error]    filter with: ProblemFilters.exclude[MissingTypesProblem]("com.twitter.bijection.scrooge.BinaryScalaCodec")
[info] bijection-core: found 0 potential binary incompatibilities
[info] bijection-hbase: found 5 potential binary incompatibilities
[error]  * object com.twitter.bijection.hbase.HBaseBijections#ImmutableBytesWritableBijection does not have a correspondent in new version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("com.twitter.bijection.hbase.HBaseBijections$ImmutableBytesWritableBijection$")
[error]  * method bigdecimal2BytesInj()com.twitter.bijection.Injection in object com.twitter.bijection.hbase.HBaseInjections does not have a correspondent in new version
[error]    filter with: ProblemFilters.exclude[MissingMethodProblem]("com.twitter.bijection.hbase.HBaseInjections.bigdecimal2BytesInj")
[error]  * object com.twitter.bijection.hbase.HBaseBijections does not have a correspondent in new version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("com.twitter.bijection.hbase.HBaseBijections$")
[error]  * class com.twitter.bijection.hbase.HBaseBijections#ImmutableBytesWritableBijection does not have a correspondent in new version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("com.twitter.bijection.hbase.HBaseBijections$ImmutableBytesWritableBijection")
[error]  * class com.twitter.bijection.hbase.HBaseBijections does not have a correspondent in new version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("com.twitter.bijection.hbase.HBaseBijections")
```