### PR TITLE
Repro ser/de failures and add tests

### DIFF
--- a/bijection-core/src/test/scala/com/twitter/bijection/BaseProperties.scala
+++ b/bijection-core/src/test/scala/com/twitter/bijection/BaseProperties.scala
@@ -16,17 +16,42 @@ limitations under the License.
 
 package com.twitter.bijection
 
-import org.scalacheck.Arbitrary
-import org.scalatest.{ PropSpec, MustMatchers }
-import org.scalatest.prop.PropertyChecks
-
-import org.scalacheck.Prop.forAll
-
-import scala.math.Equiv
-import scala.util.Success
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream, ObjectInputStream, Serializable }
 import java.util.Arrays
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop.forAll
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{ PropSpec, MustMatchers }
+import scala.math.Equiv
+import scala.reflect.ClassTag
+import scala.util.Success
 
 trait BaseProperties {
+  def jserialize[T <: Serializable](t: T): Array[Byte] = {
+    val bos = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(bos)
+    try {
+      out.writeObject(t)
+      bos.toByteArray
+    } finally {
+      out.close
+      bos.close
+    }
+  }
+  def jdeserialize[T](bytes: Array[Byte])(implicit cmf: ClassTag[T]): T = {
+    val cls = cmf.runtimeClass.asInstanceOf[Class[T]]
+    val bis = new ByteArrayInputStream(bytes)
+    val in = new ObjectInputStream(bis);
+    try {
+      cls.cast(in.readObject)
+    } finally {
+      bis.close
+      in.close
+    }
+  }
+  def jrt[T <: Serializable](t: T)(implicit cmf: ClassTag[T]): T =
+    jdeserialize(jserialize(t))
+
   implicit def barrEq[T](implicit eqt: Equiv[T]): Equiv[Array[T]] = new Equiv[Array[T]] {
     def equiv(a1: Array[T], a2: Array[T]) =
       a1.zip(a2).forall { tup: (T, T) => eqt.equiv(tup._1, tup._2) }
@@ -65,7 +90,12 @@ trait BaseProperties {
 
   def isInjection[A, B](implicit a: Arbitrary[A],
     inj: Injection[A, B], barb: Arbitrary[B], eqa: Equiv[A], eqb: Equiv[B]) =
-    isLooseInjection[A, B] && invertIsStrict[A, B]
+    isLooseInjection[A, B] &&
+    invertIsStrict[A, B] && {
+      val rtInj = jrt(inj)
+      (isLooseInjection[A, B](a, rtInj, eqa) &&
+        invertIsStrict[A, B](barb, rtInj, eqb)).label("Serialized check")
+    }
 
   def isInjective[A, B](implicit a: Arbitrary[A], bij: ImplicitBijection[A, B], eqa: Equiv[A]) =
     forAll { (a: A) => eqa.equiv(a, rt(a)(bij.bijection)) }
@@ -74,10 +104,12 @@ trait BaseProperties {
     forAll { b: B => eqb.equiv(b, rtInjective(b)(bij.bijection.inverse)) }
 
   def isBijection[A, B](implicit arba: Arbitrary[A],
-    arbb: Arbitrary[B], bij: ImplicitBijection[A, B], eqa: Equiv[A], eqb: Equiv[B]) = {
-    implicit val inj = Injection.fromBijection(bij.bijection)
-    isInjective[A, B] && invertIsInjection[A, B]
-  }
+    arbb: Arbitrary[B], bij: ImplicitBijection[A, B], eqa: Equiv[A], eqb: Equiv[B]) =
+    isInjective[A, B] && invertIsInjection[A, B] && {
+      val bij2 = jrt(bij)
+      (isInjective[A, B](arba, bij2, eqa)  &&
+        invertIsInjection[A, B](arbb, bij2, eqb)).label("Serialized check")
+    }
 
   def arbitraryViaBijection[A, B](implicit bij: Bijection[A, B], arb: Arbitrary[A]): Arbitrary[B] =
     Arbitrary { arb.arbitrary.map { bij(_) } }

--- a/bijection-core/src/test/scala/com/twitter/bijection/BaseProperties.scala
+++ b/bijection-core/src/test/scala/com/twitter/bijection/BaseProperties.scala
@@ -90,12 +90,11 @@ trait BaseProperties {
 
   def isInjection[A, B](implicit a: Arbitrary[A],
     inj: Injection[A, B], barb: Arbitrary[B], eqa: Equiv[A], eqb: Equiv[B]) =
-    isLooseInjection[A, B] &&
-    invertIsStrict[A, B] && {
-      val rtInj = jrt(inj)
-      (isLooseInjection[A, B](a, rtInj, eqa) &&
-        invertIsStrict[A, B](barb, rtInj, eqb)).label("Serialized check")
-    }
+    isLooseInjection[A, B] && invertIsStrict[A, B]
+
+  def isSerializableInjection[A, B](implicit arba: Arbitrary[A],
+    inj: Injection[A, B], barb: Arbitrary[B], eqa: Equiv[A], eqb: Equiv[B]) =
+    isInjection[A, B] && (isInjection(arba, jrt(inj), barb, eqa, eqb).label("Serializable check"))
 
   def isInjective[A, B](implicit a: Arbitrary[A], bij: ImplicitBijection[A, B], eqa: Equiv[A]) =
     forAll { (a: A) => eqa.equiv(a, rt(a)(bij.bijection)) }
@@ -105,11 +104,11 @@ trait BaseProperties {
 
   def isBijection[A, B](implicit arba: Arbitrary[A],
     arbb: Arbitrary[B], bij: ImplicitBijection[A, B], eqa: Equiv[A], eqb: Equiv[B]) =
-    isInjective[A, B] && invertIsInjection[A, B] && {
-      val bij2 = jrt(bij)
-      (isInjective[A, B](arba, bij2, eqa)  &&
-        invertIsInjection[A, B](arbb, bij2, eqb)).label("Serialized check")
-    }
+    isInjective[A, B] && invertIsInjection[A, B]
+
+  def isSerializableBijection[A, B](implicit arba: Arbitrary[A],
+    arbb: Arbitrary[B], bij: ImplicitBijection[A, B], eqa: Equiv[A], eqb: Equiv[B]) =
+    isBijection[A, B] && (isBijection(arba, arbb, jrt(bij), eqa, eqb).label("Serializable check"))
 
   def arbitraryViaBijection[A, B](implicit bij: Bijection[A, B], arb: Arbitrary[A]): Arbitrary[B] =
     Arbitrary { arb.arbitrary.map { bij(_) } }

--- a/bijection-core/src/test/scala/com/twitter/bijection/StringBijectionLaws.scala
+++ b/bijection-core/src/test/scala/com/twitter/bijection/StringBijectionLaws.scala
@@ -38,7 +38,7 @@ object StringArbs extends BaseProperties {
 class StringBijectionLaws extends CheckProperties with BaseProperties {
 
   property("round trips string -> Array[String]") {
-    isInjection[String, Array[Byte]]
+    isSerializableInjection[String, Array[Byte]]
   }
 
   implicit val symbol = arbitraryViaFn { (s: String) => Symbol(s) }
@@ -54,7 +54,7 @@ class StringBijectionLaws extends CheckProperties with BaseProperties {
   }
 
   property("UUID -> String") {
-    isInjection[UUID, String]
+    isSerializableInjection[UUID, String]
   }
 
   //property("UUID <-> String @@ Rep[UUID]") {
@@ -70,7 +70,7 @@ class StringBijectionLaws extends CheckProperties with BaseProperties {
 
   // This is trivially a bijection if it injective
   property("URL -> String") {
-    isInjection[URL, String]
+    isSerializableInjection[URL, String]
   }
 
   property("rts through StringJoinBijection") {


### PR DESCRIPTION
not fixed yet:

```
[info] - round trip List[Int] <=> Vector[String @@ Rep[Int]] *** FAILED ***
[info]   NotSerializableException was thrown during property evaluation.
[info]     Message: scala.collection.generic.GenTraversableFactory$ReusableCBF
[info]     Occurred when passed generated values (
[info]   
[info]     )

[info] - round trip Vector[Double] <=> Vector[String @@ Rep[Double]] *** FAILED ***
[info]   NotSerializableException was thrown during property evaluation.
[info]     Message: scala.collection.IndexedSeq$$anon$1
[info]     Occurred when passed generated values (
[info]   
[info]     )
[info] - round trip Set[Double] <=> Set[String @@ Rep[Double]] *** FAILED ***
[info]   NotSerializableException was thrown during property evaluation.
[info]     Message: scala.collection.generic.GenSetFactory$$anon$1
[info]     Occurred when passed generated values (
[info]   
[info]     )
[info] - round trip Seq[Double] <=> Seq[String @@ Rep[Double]] *** FAILED ***
[info]   NotSerializableException was thrown during property evaluation.
[info]     Message: scala.LowPriorityImplicits$$anon$1
[info]     Occurred when passed generated values (
[info]   
[info]     )
[info] - round trip Map[Long,Double] <=> Map[String @@ Rep[Long], String @@ Rep[Double]] *** FAILED ***
[info]   NotSerializableException was thrown during property evaluation.
[info]     Message: scala.collection.generic.GenMapFactory$MapCanBuildFrom
[info]     Occurred when passed generated values (
[info]   
[info]     )
[info] - round trips string -> Array[String] *** FAILED ***
[info]   NotSerializableException was thrown during property evaluation.
[info]     Message: com.twitter.bijection.AtomicSharedState
[info]     Occurred when passed generated values (
[info]   
[info]     )
```