### PR TITLE
Fix an integral float overflow for very large strings

### DIFF
--- a/bijection-core/src/main/scala/com/twitter/bijection/StringInjections.scala
+++ b/bijection-core/src/main/scala/com/twitter/bijection/StringInjections.scala
@@ -53,7 +53,7 @@ trait StringInjections extends NumericInjections {
           val decBuf = decRef.get
           val dec = decBuf._1
           val buf = decBuf._2
-          val maxSpace = (b.length * dec.maxCharsPerByte).toInt + 1
+          val maxSpace = (b.length * (dec.maxCharsPerByte.toDouble)).toInt + 1
           val thisBuf = if (maxSpace > buf.limit) CharBuffer.allocate(maxSpace) else buf
 
           // this is the error free result

--- a/bijection-core/src/test/scala/com/twitter/bijection/StringBijectionLaws.scala
+++ b/bijection-core/src/test/scala/com/twitter/bijection/StringBijectionLaws.scala
@@ -22,6 +22,7 @@ import java.util.UUID
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen._
 import org.scalacheck.Prop._
+import org.scalatest.FunSuite
 
 import scala.util.Try
 
@@ -33,6 +34,15 @@ object StringArbs extends BaseProperties {
   implicit val strLong = arbitraryViaBijection[Long, String @@ Rep[Long]]
   implicit val strFloat = arbitraryViaBijection[Float, String @@ Rep[Float]]
   implicit val strDouble = arbitraryViaBijection[Double, String @@ Rep[Double]]
+}
+/**
+ * We had an issue with giant strings. Make sure they work
+ */
+class StringRegressions extends FunSuite {
+  test("Strings larger that 2^24, the largest integer range floats can store work") {
+    val bigString = Array.fill(70824427)(42.toByte)
+    assert(Injection.utf8.invert(bigString).isSuccess)
+  }
 }
 
 class StringBijectionLaws extends CheckProperties with BaseProperties {


### PR DESCRIPTION
we hit this with a 70MB string. Work around by removing a byte. Better to fix.