### PR TITLE
Bump scala version to 2.11.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val sharedSettings = Project.defaultSettings ++ osgiSettings ++ scalariformSetti
 
   ScalariformKeys.preferences := formattingPreferences,
 
-  scalaVersion := "2.10.5",
+  scalaVersion := "2.11.7",
 
   javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
 


### PR DESCRIPTION
While investigating some dbuild failures on our OSS projects, noticed that the scalaVersion in bijection was set to 2.10.x (this resulted in some cross-version compatibility issues). Setting it to 2.11.7 (we still create artifacts for 2.10.x). 
