### PR TITLE
Add support for Tuple1 bijections

### DIFF
--- a/bijection-macros/src/main/scala/com/twitter/bijection/macros/impl/CaseClassToTuple.scala
+++ b/bijection-macros/src/main/scala/com/twitter/bijection/macros/impl/CaseClassToTuple.scala
@@ -43,6 +43,8 @@ private[bijection] object CaseClassToTuple {
 
     //TODO can make error handling better
     val companion = T.tpe.typeSymbol.companionSymbol
+    val tuple = Tup.tpe.typeSymbol.companionSymbol
+
     val getPutConv = T.tpe
       .declarations
       .collect { case m: MethodSymbol if m.isCaseAccessor => m }
@@ -73,7 +75,7 @@ private[bijection] object CaseClassToTuple {
     new Bijection[$T,$Tup] with MacroGenerated {
       override def apply(t: $T): $Tup = {
         ..$converters
-        (..$putters)
+        $tuple(..$putters)
       }
       override def invert(tup: $Tup): $T = {
         ..$converters

--- a/project/BufferableGenerator.scala
+++ b/project/BufferableGenerator.scala
@@ -29,7 +29,7 @@ object BufferableGenerator {
   def typeList(cnt: Int) =
     upperLetters.slice(0, cnt) map { _.toString } mkString(",")
 
-  def parensTypeList(cnt: Int) = "(" + typeList(cnt) + ")"
+  def tupleTypeList(cnt: Int) = "Tuple" + cnt + "[" + typeList(cnt) + "]"
 
   def reallocatingPut(idx: Int) =
     "nextBb = reallocatingPut(nextBb) { b" + lowerLetters(idx) + ".put(_, tup._" + (idx+1) +") }"
@@ -46,15 +46,15 @@ object BufferableGenerator {
   def implicitTuple(cnt: Int): String =
     "  implicit def tuple" + cnt + "[" + typeList(cnt) + "](implicit " +
       ((0 until cnt) map { bufferableParam(_) } mkString(", ") ) + "):\n" +
-    "    Bufferable[" + parensTypeList(cnt) + "] = new AbstractBufferable[" + parensTypeList(cnt) +"] {\n" +
-    "      def put(bytebuf: ByteBuffer, tup: "+ parensTypeList(cnt) +") = {\n" +
+    "    Bufferable[" + tupleTypeList(cnt) + "] = new AbstractBufferable[" + tupleTypeList(cnt) +"] {\n" +
+    "      def put(bytebuf: ByteBuffer, tup: "+ tupleTypeList(cnt) +") = {\n" +
     "        var nextBb = bytebuf\n" +
     "        " + ((0 until cnt) map { reallocatingPut(_) }).mkString("","\n        ","\n") +
     "        nextBb\n" +
     "      }\n"+
     "      def get(bytebuf: ByteBuffer) = attempt(bytebuf) { bytebuf =>\n" +
     "        " + ((0 until cnt) map { bufferGet(_) }).mkString("","\n        ","\n") +
-    "        val res = " +(0 until cnt).map { lowerLetters(_) }.mkString("(",", ",")") + "\n" +
+    "        val res = Tuple" + cnt +(0 until cnt).map { lowerLetters(_) }.mkString("(",", ",")") + "\n" +
     "        (buf" + lowerLetters(cnt - 1) +", res)\n" +
     "      }\n" +
     "    }"
@@ -69,7 +69,7 @@ object BufferableGenerator {
     b.append("import com.twitter.bijection.Inversion.attempt\n")
 
     b.append("\ntrait GeneratedTupleBufferable {\n")
-    (2 to 22).foreach { cnt => b.append(implicitTuple(cnt)).append("\n") }
+    (1 to 22).foreach { cnt => b.append(implicitTuple(cnt)).append("\n") }
     b.append("}")
 
     b.toString


### PR DESCRIPTION
- Add support for Bufferable injection from Tuple1[T] to Array[Byte]
- Add support for injection from a case class with one element to a
  Tuple1[T]

Testing:
$ ./sbt bijection-macros/console

scala> import com.twitter.bijection.{Bijection, Bufferable, Injection, macros}
scala> import macros._
scala> import MacroImplicits._
scala> case class Foo(v: Long)
scala> implicit val fooToByteArray = Bufferable.injectionOf[Tuple1[Long]]
scala> val fooInjection = Injection.connect[Foo, Tuple1[Long], Array[Byte]]
