### PR TITLE
Add support for Scala 2.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ matrix:
 
     - scala: 2.12.0
       jdk: oraclejdk8
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test"
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ matrix:
       script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION coverage" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.12.0
-          script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION coverage" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION coverage" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ sudo: false
 matrix:
   include:
     - scala: 2.10.6
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean"  "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION scalafmtTest" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.11.8
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION scalafmtTest" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.12.0
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION scalafmtTest" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ sudo: false
 matrix:
   include:
     - scala: 2.10.6
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean scalafmtTest test mimaReportBinaryIssues
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean"  "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.11.8
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean scalafmtTest coverage test coverageReport mimaReportBinaryIssues
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION coverage" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
+
+    - scala: 2.12.0
+          script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION coverage" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION scalafmtTest" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.12.0
+      jdk: oraclejdk8
       script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ matrix:
       script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION scalafmtTest" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.12.0
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION scalafmtTest" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ matrix:
       script: ./sbt "+++$TRAVIS_SCALA_VERSION clean"  "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.11.8
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION coverage" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.12.0
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION coverage" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION coverageReport" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import bijection._
 
 val buildLevelSettings = Seq(
   organization := "com.twitter",
-  crossScalaVersions := Seq("2.10.6", "2.11.8"),
+  crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0"),
   scalaVersion := "2.11.8",
   javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
   javacOptions in doc := Seq("-source", "1.6"),
@@ -141,7 +141,7 @@ lazy val bijection = {
     id = "bijection",
     base = file("."),
     settings = sharedSettings
-  ).enablePlugins(DocGen, SbtOsgi)
+  ).enablePlugins(DocGen, SbtOsgi, CrossPerProjectPlugin)
   .settings(
     test := {},
     publish := {}, // skip publishing for this root project.
@@ -244,6 +244,7 @@ lazy val bijectionGuava = {
 
 lazy val bijectionScrooge = {
   module("scrooge").settings(
+    crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12")),
     osgiExportAll("com.twitter.bijection.scrooge"),
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % "0.6.1" exclude ("junit", "junit"),
@@ -269,6 +270,7 @@ lazy val bijectionJson = {
 
 lazy val bijectionUtil = {
   module("util").settings(
+    crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12")),
     osgiExportAll("com.twitter.bijection.twitter_util"),
     libraryDependencies += "com.twitter" %% "util-core" % "6.24.0"
   ).dependsOn(
@@ -278,6 +280,7 @@ lazy val bijectionUtil = {
 
 lazy val bijectionFinagleMySql = {
   module("finagle-mysql").settings(
+    crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12")),
     osgiExportAll("com.twitter.bijection.finagle_mysql"),
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-mysql" % "6.25.0",
@@ -347,8 +350,8 @@ lazy val bijectionJson4s = {
     osgiExportAll("com.twitter.bijection.json4s"),
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "org.json4s" %% "json4s-native" % "3.2.10",
-      "org.json4s" %% "json4s-ext" % "3.2.10"
+      "org.json4s" %% "json4s-native" % "3.5.0",
+      "org.json4s" %% "json4s-ext" % "3.5.0"
     )
   ).dependsOn(
     bijectionCore % "test->test;compile->compile"

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ val buildLevelSettings = Seq(
   scalaVersion := "2.11.8",
   javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
   javacOptions in doc := Seq("-source", "1.6"),
+  coverageEnabled := true,
   scalacOptions ++= Seq(
     "-unchecked",
     "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,10 @@ import bijection._
 val buildLevelSettings = Seq(
   organization := "com.twitter",
   crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0"),
-  scalaVersion := "2.11.8",
   javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
   javacOptions in doc := Seq("-source", "1.6"),
-  coverageEnabled := true,
+  scalaVersion := "2.11.8",
+  coverageEnabled := (if (scalaVersion.value startsWith "2.11") true else false),
   scalacOptions ++= Seq(
     "-unchecked",
     "-deprecation",
@@ -67,7 +67,6 @@ val buildLevelSettings = Seq(
     )
   )
 )
-inThisBuild(buildLevelSettings)
 
 val sharedSettings = Seq(
   // Publishing options:
@@ -141,7 +140,7 @@ lazy val bijection = {
   Project(
     id = "bijection",
     base = file("."),
-    settings = sharedSettings
+    settings = buildLevelSettings ++ sharedSettings 
   ).enablePlugins(DocGen, SbtOsgi, CrossPerProjectPlugin)
   .settings(
     test := {},
@@ -170,7 +169,7 @@ def module(name: String) = {
   val id = s"bijection-$name"
   Project(id = id, base = file(id))
     .enablePlugins(SbtOsgi)
-    .settings(sharedSettings)
+    .settings(buildLevelSettings ++ sharedSettings)
     .settings(
       mimaPreviousArtifacts := youngestForwardCompatible(name),
       mimaBinaryIssueFilters ++= ignoredABIProblems

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,7 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.11")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")

--- a/sbt
+++ b/sbt
@@ -4,8 +4,8 @@
 # Author: Paul Phillips <paulp@improving.org>
 
 # todo - make this dynamic
-declare -r sbt_release_version="0.13.12"
-declare -r sbt_unreleased_version="0.13.12"
+declare -r sbt_release_version="0.13.13"
+declare -r sbt_unreleased_version="0.13.13"
 declare -r buildProps="project/build.properties"
 
 declare sbt_jar sbt_dir sbt_create sbt_version


### PR DESCRIPTION
Building on https://github.com/twitter/bijection/pull/257. Adding 2.12.0 as a cross version to include. Had to disable building 2.12 for a few projects as they require some finagle 2.12 artifacts (which in turn requires bijection-core 2.12). Once the finagle artifacts are in, we can reenable those projects. 