### PR TITLE
Update README to list new versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ A list of contributors to the project can be found here: [Contributors](https://
 
 ## Maven
 
-Bijection modules are available on maven central. The current groupid and version for all modules is, respectively, `"com.twitter"` and  `0.9.2`.
+Bijection modules are available on maven central. The current groupid and version for all modules is, respectively, `"com.twitter"` and  `0.9.3`.
 
 Current published artifacts are
 
@@ -160,9 +160,9 @@ Current published artifacts are
 * `bijection-avro`
 * `bijection-hbase`
 
-Every artifact is published against Scala `"2.10"` and `"2.11"`. To pull in the jars, make sure to add your desired scala version as a suffix, ie:
+Every artifact is published against Scala `"2.10"` and `"2.11"`. We currently publish a subset of bijection's modules against Scala `"2.12"`.  Bijection modules - bijection-util and bijection-scrooge depend on other projects to publish 2.12 artifacts and currently aren't being published. To pull in the jars, make sure to add your desired scala version as a suffix, ie:
 
-`bijection-core_2.10` or `bijection-core_2.11`
+`bijection-core_2.10` or `bijection-core_2.11` or `bijection-core_2.12`. 
 
 ## Chat
 [![Gitter](https://badges.gitter.im/twitter/bijection.svg)](https://gitter.im/twitter/bijection?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ A list of contributors to the project can be found here: [Contributors](https://
 
 ## Maven
 
-Bijection modules are available on maven central. The current groupid and version for all modules is, respectively, `"com.twitter"` and  `0.9.3`.
+Bijection modules are available on maven central. The current groupid and version for all modules is, respectively, `"com.twitter"` and  `0.9.4`.
 
 Current published artifacts are
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.3"
+version in ThisBuild := "0.9.4-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.4-SNAPSHOT"
+version in ThisBuild := "0.9.5-SNAPSHOT"


### PR DESCRIPTION
Published 0.9.4 jars to sonatype (e.g https://oss.sonatype.org/content/repositories/releases/com/twitter/bijection-core_2.12/). Updated the README and version to go with this. 