### PR TITLE
Add support to publish all bijection modules with Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
       script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.11.8
+      jdk: oraclejdk8
       script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage scalafmtTest test coverageReport mimaReportBinaryIssues
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 matrix:
   include:
     - scala: 2.10.6
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean scalafmtTest test mimaReportBinaryIssues
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.11.8
       script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage scalafmtTest test coverageReport mimaReportBinaryIssues
@@ -12,7 +12,7 @@ matrix:
 
     - scala: 2.12.1
       jdk: oraclejdk8
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test"
+      script: ./sbt ++$TRAVIS_SCALA_VERSION clean test
 
 cache:
   directories:

--- a/bijection-finagle-mysql/src/main/scala/com/twitter/bijection/finagle_mysql/MySqlConversions.scala
+++ b/bijection-finagle-mysql/src/main/scala/com/twitter/bijection/finagle_mysql/MySqlConversions.scala
@@ -16,10 +16,10 @@ limitations under the License.
 
 package com.twitter.bijection.finagle_mysql
 
-import com.twitter.finagle.exp.mysql._
 import com.twitter.bijection._
+import com.twitter.finagle.mysql._
 import java.sql.Timestamp
-import scala.util.{Try, Success, Failure}
+import scala.util.{Failure, Success, Try}
 
 /**
   * Bijections and injections for mapping twitter-finagle's MySql datatypes to Scala datatypes

--- a/bijection-finagle-mysql/src/test/scala/com/twitter/bijection/finagle_mysql/MySqlConversionLaws.scala
+++ b/bijection-finagle-mysql/src/test/scala/com/twitter/bijection/finagle_mysql/MySqlConversionLaws.scala
@@ -18,7 +18,7 @@ package com.twitter.bijection.finagle_mysql
 
 import com.twitter.bijection.{CheckProperties, BaseProperties, Bijection}
 import org.scalacheck.Arbitrary
-import com.twitter.finagle.exp.mysql._
+import com.twitter.finagle.mysql._
 import java.sql.Timestamp
 import java.util.Date
 


### PR DESCRIPTION
As the finagle 2.12 jars are out, picking them up and publishing all bijection modules in 2.12. Finagle has stopped supporting 2.10 (http://finagle.github.io/blog/2016/04/20/scala-210-and-java7/) and they've since moved a bunch of packages around. I've turned off building / publishing bijectionFinagleMySql for 2.10 to get around this. We could also go the finagle route and stop building / publishing for 2.10. 

Also made a couple of changes to some test code to get around some code in ScalaRuntime being dropped. 