### PR TITLE
Update Twitter OSS dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,16 +6,16 @@ import ReleaseTransformations._ // for sbt-release.
 import bijection._
 
 val finagleVersion210 = "6.35.0"
-val finagleVersion = "6.41.0"
+val finagleVersion = "6.45.0"
 
 val scalatestVersion = "3.0.1"
 val scalacheckVersion = "1.13.4"
 
 val utilVersion210 = "6.34.0"
-val utilVersion = "6.39.0"
+val utilVersion = "6.45.0"
 
 val scroogeSerializerVersion210 = "3.17.0"
-val scroogeSerializerVersion = "4.13.0"
+val scroogeSerializerVersion = "4.18.0"
 
 def util(mod: String, scalaVersion: String) = {
   val version = versionFallback(scalaVersion, utilVersion210, utilVersion)


### PR DESCRIPTION
Problem: 

The versions of Twitter dependencies are quite far behind. 

Solution:

Update dependency versions for Twitter libraries.
- util -> 6.45.0
- scrooge -> 4.18.0
- finagle -> 6.45.0