### PR TITLE
Clean up the build and fix some tests

### DIFF
--- a/bijection-core/src/test/scala/com/twitter/bijection/BaseProperties.scala
+++ b/bijection-core/src/test/scala/com/twitter/bijection/BaseProperties.scala
@@ -138,3 +138,5 @@ trait BaseProperties {
   def arbitraryViaInjection[A, B](implicit inj: Injection[A, B], arb: Arbitrary[A]): Arbitrary[B] =
     Arbitrary { arb.arbitrary.map { inj(_) } }
 }
+
+object BaseProperties extends BaseProperties

--- a/bijection-core/src/test/scala/com/twitter/bijection/CollectionLaws.scala
+++ b/bijection-core/src/test/scala/com/twitter/bijection/CollectionLaws.scala
@@ -102,4 +102,16 @@ class CollectionLaws extends CheckProperties with BaseProperties {
   property("round trip Set[Int] -> List[String]") {
     isInjection[Set[Int], List[String]]
   }
+
+  property("round trip Set[Int] -> Vector[String]") {
+    isInjection[Set[Int], Vector[String]]
+  }
+
+  property("round trip List[Int] -> List[String]") {
+    isInjection[List[Int], List[String]]
+  }
+
+  property("round trip Set[Int] -> Set[String]") {
+    isInjection[Set[Int], Set[String]]
+  }
 }

--- a/bijection-core/src/test/scala/com/twitter/bijection/CollectionLaws.scala
+++ b/bijection-core/src/test/scala/com/twitter/bijection/CollectionLaws.scala
@@ -83,6 +83,18 @@ class CollectionLaws extends CheckProperties with BaseProperties {
     isBijection[Vector[Int], IndexedSeq[Int]]
   }
 
+  property("Seq[Long] <=> IndexedSeq[Long]") {
+    isBijection[Seq[Long], IndexedSeq[Long]]
+  }
+
+  property("Seq[Long] <=> List[Long]") {
+    isBijection[Seq[Long], List[Long]]
+  }
+
+  property("IndexedSeq[Long] <=> IndexedSeq[(Int, Int)]") {
+    isBijection[IndexedSeq[Long], IndexedSeq[(Int, Int)]]
+  }
+
   property("List[Int] <=> IndexedSeq[String @@ Rep[Int]]") {
     isBijection[List[Int], IndexedSeq[String @@ Rep[Int]]]
   }

--- a/bijection-core/src/test/scala/com/twitter/bijection/NumericBijectionLaws.scala
+++ b/bijection-core/src/test/scala/com/twitter/bijection/NumericBijectionLaws.scala
@@ -162,36 +162,36 @@ class NumericBijectionLaws extends PropSpec {
   property("Int -> (Int,Int) by ModDiv") {
     forAll(Gen.choose(1, Int.MaxValue)) { mod =>
       implicit val modDiv: Injection[Int, (Int, Int)] = new IntModDivInjection(mod)
-      isInjection[Int, (Int, Int)]
+      check(isInjection[Int, (Int, Int)])
     }
   }
 
   property("Long -> (Long,Long) by ModDiv") {
     forAll(Gen.choose(1L, Long.MaxValue)) { mod =>
       implicit val modDiv: Injection[Long, (Long, Long)] = new LongModDivInjection(mod)
-      isInjection[Long, (Long, Long)]
+      check(isInjection[Long, (Long, Long)])
     }
   }
 
   // TODO need Rep[Int], etc... on the Array[Byte]
   property("round trips short -> Array[Byte]") {
-    isLooseInjection[Short, Array[Byte]]
+    check(isLooseInjection[Short, Array[Byte]])
   }
 
   property("round trips int -> Array[Byte]") {
-    isLooseInjection[Int, Array[Byte]]
+    check(isLooseInjection[Int, Array[Byte]])
   }
 
   property("round trips long -> Array[Byte]") {
-    isLooseInjection[Long, Array[Byte]]
+    check(isLooseInjection[Long, Array[Byte]])
   }
 
   property("round trips float -> Array[Byte]") {
-    isLooseInjection[Float, Array[Byte]]
+    check(isLooseInjection[Float, Array[Byte]])
   }
 
   property("round trips double -> Array[Byte]") {
-    isLooseInjection[Double, Array[Byte]]
+    check(isLooseInjection[Double, Array[Byte]])
   }
 
   // Some other types through numbers:
@@ -202,11 +202,11 @@ class NumericBijectionLaws extends PropSpec {
     new java.util.Date(dtime)
   }
   property("round trips (Long,Long) -> UUID") {
-    isBijection[(Long, Long), UUID]
+    check(isBijection[(Long, Long), UUID])
   }
 
   property("round trips Long -> Date") {
-    isBijection[Long, java.util.Date]
+    check(isBijection[Long, java.util.Date])
   }
 
   property("as works") {

--- a/bijection-core/src/test/scala/com/twitter/bijection/NumericBijectionLaws.scala
+++ b/bijection-core/src/test/scala/com/twitter/bijection/NumericBijectionLaws.scala
@@ -28,14 +28,17 @@ import java.lang.{
 import java.math.BigInteger
 import java.util.UUID
 
-import org.scalacheck.Gen
+import org.scalacheck.{ Gen, Prop }
 
-import org.scalatest.{PropSpec, MustMatchers}
-import org.scalatest.prop.PropertyChecks
+import org.scalatest.{PropSpec, Tag => stTag}
+import org.scalatest.prop.{ Checkers, PropertyChecks }
+import Checkers.check
+import PropertyChecks.forAll
 
 import Conversion.asMethod // get the .as syntax
 
-object JavaNumArbs extends BaseProperties {
+object JavaNumArbs {
+  import BaseProperties._
 
   implicit val byteA = arbitraryViaFn { v: Byte =>
     JByte.valueOf(v)
@@ -60,102 +63,99 @@ object JavaNumArbs extends BaseProperties {
   }
 }
 
-class NumericBijectionLaws
-    extends PropSpec
-    with PropertyChecks
-    with MustMatchers
-    with BaseProperties {
+class NumericBijectionLaws extends PropSpec {
   import StringArbs._
   import JavaNumArbs._
+  import BaseProperties._
 
   property("round trips byte -> jbyte") {
-    isBijection[Byte, JByte]
+    check(isBijection[Byte, JByte])
   }
 
   property("round trips short -> jshort") {
-    isBijection[Short, JShort]
+    check(isBijection[Short, JShort])
   }
 
   property("round trips int -> jint") {
-    isBijection[Int, JInt]
+    check(isBijection[Int, JInt])
   }
 
   property("round trips long -> jlong") {
-    isBijection[Long, JLong]
+    check(isBijection[Long, JLong])
   }
 
   property("round trips float -> jfloat") {
-    isBijection[Float, JFloat]
+    check(isBijection[Float, JFloat])
   }
 
   property("round trips double -> jdouble") {
-    isBijection[Double, JDouble]
+    check(isBijection[Double, JDouble])
   }
 
   property("round trips BigInt <-> java.math.BigInteger") {
-    isBijection[BigInt, BigInteger]
+    check(isBijection[BigInt, BigInteger])
   }
 
   property("round trips byte -> string") {
-    isBijection[Byte, String @@ Rep[Byte]]
+    check(isBijection[Byte, String @@ Rep[Byte]])
   }
 
   property("round trips short -> string") {
-    isBijection[Short, String @@ Rep[Short]]
+    check(isBijection[Short, String @@ Rep[Short]])
   }
 
   property("round trips int -> string") {
-    isBijection[Int, String @@ Rep[Int]]
+    check(isBijection[Int, String @@ Rep[Int]])
   }
 
   property("round trips long -> string") {
-    isBijection[Long, String @@ Rep[Long]]
+    check(isBijection[Long, String @@ Rep[Long]])
   }
 
   property("round trips float -> string") {
-    isBijection[Float, String @@ Rep[Float]]
+    check(isBijection[Float, String @@ Rep[Float]])
   }
 
   property("round trips double -> string") {
-    isBijection[Double, String @@ Rep[Double]]
+    check(isBijection[Double, String @@ Rep[Double]])
   }
 
   // Embedding in larger numbers:
   property("round trips Short <-> (Byte,Byte)") {
-    isBijection[Short, (Byte, Byte)]
+    check(isBijection[Short, (Byte, Byte)])
   }
 
   property("round trips Int <-> (Short,Short)") {
-    isBijection[Int, (Short, Short)]
+    check(isBijection[Int, (Short, Short)])
   }
 
   property("round trips Long <-> (Int,Int)") {
-    isBijection[Long, (Int, Int)]
+    check(isBijection[Long, (Int, Int)])
   }
 
   // Upcasting:
   property("byte -> short") {
-    isInjection[Byte, Short]
+    check(isInjection[Byte, Short])
   }
 
   property("short -> int") {
-    isInjection[Short, Int]
+    check(isInjection[Short, Int])
   }
 
   property("int -> long") {
-    isInjection[Int, Long]
+    check(isInjection[Int, Long])
   }
 
   property("long -> BigInt") {
-    isInjection[Long, BigInt]
+    check(isInjection[Long, BigInt])
   }
 
   property("int -> double") {
-    isLooseInjection[Int, Double]
+    check(isLooseInjection[Int, Double])
   }
 
   property("float -> double") {
-    isLooseInjection[Float, Double]
+    check(isLooseInjection[Float, Double])
   }
 
   // ModDiv

--- a/bijection-core/src/test/scala/com/twitter/bijection/StringBijectionLaws.scala
+++ b/bijection-core/src/test/scala/com/twitter/bijection/StringBijectionLaws.scala
@@ -26,7 +26,8 @@ import org.scalatest.FunSuite
 
 import scala.util.Try
 
-object StringArbs extends BaseProperties {
+object StringArbs {
+  import BaseProperties._
 
   implicit val strByte = arbitraryViaBijection[Byte, String @@ Rep[Byte]]
   implicit val strShort = arbitraryViaBijection[Short, String @@ Rep[Short]]

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,10 +2,10 @@ resolvers ++= Seq(
   "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 )
 
-addSbtPlugin("com.github.gseitz" % "sbt-release"     % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release"     % "1.0.6")
 addSbtPlugin("com.eed3si9n"      % "sbt-doge"        % "0.1.5")
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"         % "1.0.0")
-addSbtPlugin("com.typesafe"      % "sbt-mima-plugin" % "0.1.12")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"         % "1.1.0")
+addSbtPlugin("com.typesafe"      % "sbt-mima-plugin" % "0.1.17")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"     % "0.5.4")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-osgi"        % "0.8.0")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"   % "1.5.0")


### PR DESCRIPTION
We migrated the tests long ago from scalacheck driven to scalatest driven.

We missed some of the correct conversion so some of the tests are no-op.

Side note, I pretty much hate how flexible scalatest is. It is very difficult to see if something is a no-op. This have been disabled for years.

Probably more are also but I didn't run them down yet.