### PR TITLE
build on openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,17 @@ sudo: false
 matrix:
   include:
     - scala: 2.10.6
+      jdk: openjdk8
       script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
 
     - scala: 2.11.8
-      jdk: oraclejdk8
+      jdk: openjdk8
       script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage scalafmtTest test coverageReport mimaReportBinaryIssues
       after_success:
         - bash <(curl -s https://codecov.io/bash)
 
     - scala: 2.12.1
-      jdk: oraclejdk8
+      jdk: openjdk8
       script: ./sbt ++$TRAVIS_SCALA_VERSION clean test
 
 cache:


### PR DESCRIPTION
Problem: Travis build validation doesn't work anymore because oracleJDK8 isn't supported anymore

Solution: Migrate to openjdk8

Effect: Working PR validation