### PR TITLE
Update scala versions 2.11.12 and 2.12.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: scala
 sudo: false
 matrix:
   include:
-    - scala: 2.11.8
+    - scala: 2.11.12
       jdk: openjdk8
       script: ./sbt ++$TRAVIS_SCALA_VERSION clean test
 
-    - scala: 2.12.1
+    - scala: 2.12.8
       jdk: openjdk8
       script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage scalafmtCheck test:scalafmtCheck test coverageReport mimaReportBinaryIssues
       after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -144,6 +144,12 @@ val ignoredABIProblems = {
     ),
     exclude[ReversedMissingMethodProblem](
       "com.twitter.bijection.twitter_util.UtilBijections.twitter2JavaFutureInjection"
+    ),
+    exclude[DirectMissingMethodProblem](
+      "com.twitter.bijection.netty.ChannelBufferBijection.invert"
+    ),
+    exclude[DirectMissingMethodProblem](
+      "com.twitter.bijection.Bijection.trav2Vector"
     )
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -27,10 +27,11 @@ def scroogeSerializer = {
 
 val buildLevelSettings = Seq(
   organization := "com.twitter",
-  crossScalaVersions := Seq("2.11.8", "2.12.1"),
+  crossScalaVersions := Seq("2.11.12", scalaVersion.value),
   javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
-  javacOptions in doc := Seq("-source", "1.6"),
-  scalaVersion := "2.12.1",
+  javacOptions in doc := Seq("-source", "1.6",    "-Xlint:deprecation",
+  "-Xlint:unchecked"),
+  scalaVersion := "2.12.8",
   scalacOptions ++= Seq(
     "-unchecked",
     "-deprecation",


### PR DESCRIPTION
We can't go up to `2.12.10`; there's a bug around value classes https://github.com/scala/bug/issues/11771 that will affect `Bijection` type when used in java.
