### PR TITLE
bijection: 2.12.8 -> 2.12.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ matrix:
           "++$TRAVIS_SCALA_VERSION test"
 
     - name: checks
-      scala: 2.12.8
+      scala: 2.12.10
       jdk: openjdk8
       script: sbt scalafmtCheckAll scalafmtSbtCheck
         
-    - scala: 2.12.8
+    - scala: 2.12.10
       jdk: openjdk8
       script:
         - >

--- a/bijection-core/src/test/java/com/twitter/bijection/TestBijectionInJava.java
+++ b/bijection-core/src/test/java/com/twitter/bijection/TestBijectionInJava.java
@@ -49,16 +49,20 @@ public class TestBijectionInJava extends JUnitSuite {
     //TODO include a cleaner way to get to the scala Bijections than Bijection$.MODULE$.
     @Test
     public void testBase64Bijection() {
-        // Note, value classes return the underlying types in Java. But Java users usually
-        // don't care much about type safety, so punting on this for now
-        Bijection<byte[], String> bytes2Base64 = Bijection$.MODULE$.bytes2Base64();
+        //https://github.com/scala/scala/pull/8127
+        //generic AnyVal signatures pre-2.12.9 incorrectly had the underlying
+        //type, while in reality it's the boxed AnyVal
+        //the cast is required only for 2.11.x
+        Bijection<byte[], Base64String> bytes2Base64 = (Bijection<byte[], Base64String>)(Object)Bijection$.MODULE$.bytes2Base64();
     }
 
     @Test
     public void testBase64BijectionGzip() {
-        // Note, value classes return the underlying types in Java. But Java users usually
-        // don't care much about type safety, so punting on this for now
-        Bijection<byte[], String> bytes2GZippedBase64 = Bijection$.MODULE$.bytes2GZippedBase64();
+        //https://github.com/scala/scala/pull/8127
+        //generic AnyVal signatures pre-2.12.9 incorrectly had the underlying
+        //type, while in reality it's the boxed AnyVal
+        //the cast is required only for 2.11.x
+        Bijection<byte[], GZippedBase64String> bytes2GZippedBase64 = (Bijection<byte[], GZippedBase64String>)(Object)Bijection$.MODULE$.bytes2GZippedBase64();
     }
 
     // Instantiate a Bijection to String // Looks like the Long is erased


### PR DESCRIPTION
Consequences for Java re-users:

2.12.9+ fixes a bug where `Bijection<A, B>` where `B` (or `A` for that matter) was a value class (`extends AnyVal`) was in the class file signature erroneously reported as the underlying type.

In reality, the Bijection returned an actual `AnyVal` instantiation.  Java code had to work around this bug by either casting the bijection, or casting the result.

This PR fixes the problem, which may break the java code dealing with the problem.

Binary compatibility is unaffected.