### PR TITLE
upgrade ScalaTest to 3.2.0

### DIFF
--- a/bijection-core/src/main/scala/com/twitter/bijection/Bufferable.scala
+++ b/bijection-core/src/main/scala/com/twitter/bijection/Bufferable.scala
@@ -75,7 +75,7 @@ object Bufferable
   def getBytes(from: ByteBuffer, start: Int = 0): Array[Byte] = {
     val fromd = from.duplicate
     // read position:
-    val current = fromd.position
+    val current = fromd.position()
     // set the position:
     fromd.position(start)
     val result = Array.ofDim[Byte](current - start)
@@ -111,7 +111,7 @@ object Bufferable
       ByteBuffer.allocate(newCapacity)
     }
     val tmpBb = bb.duplicate
-    val currentPos = tmpBb.position
+    val currentPos = tmpBb.position()
     tmpBb.position(0)
     tmpBb.limit(currentPos)
     newBb.put(tmpBb)

--- a/bijection-core/src/main/scala/com/twitter/bijection/StringInjections.scala
+++ b/bijection-core/src/main/scala/com/twitter/bijection/StringInjections.scala
@@ -53,7 +53,7 @@ trait StringInjections extends NumericInjections {
           val dec = decBuf._1
           val buf = decBuf._2
           val maxSpace = (b.length * (dec.maxCharsPerByte.toDouble)).toInt + 1
-          val thisBuf = if (maxSpace > buf.limit) CharBuffer.allocate(maxSpace) else buf
+          val thisBuf = if (maxSpace > buf.limit()) CharBuffer.allocate(maxSpace) else buf
 
           // this is the error free result
           @inline def assertUnderFlow(cr: CoderResult): Unit =

--- a/bijection-core/src/test/scala/com/twitter/bijection/BufferableLaws.scala
+++ b/bijection-core/src/test/scala/com/twitter/bijection/BufferableLaws.scala
@@ -27,10 +27,10 @@ trait BaseBufferable {
       val buf = ByteBuffer.allocateDirect(100)
       val newBuf = Bufferable.put(buf, t)
       val newBuf2 = ByteBuffer.wrap(Bufferable.getBytes(newBuf))
-      val pos = newBuf2.position
+      val pos = newBuf2.position()
       val (newBuf3, rtt) = Bufferable.get[T](newBuf2).get
       val copyT = Bufferable.deepCopy(t)
-      Equiv[T].equiv(t, rtt) && Equiv[T].equiv(t, copyT) && (newBuf2.position == pos)
+      Equiv[T].equiv(t, rtt) && Equiv[T].equiv(t, copyT) && (newBuf2.position() == pos)
     }
   implicit protected def aeq[T: Equiv]: Equiv[Array[T]] =
     Equiv.fromFunction { (a1, a2) =>
@@ -50,7 +50,7 @@ class BufferableLaws extends CheckProperties with BaseBufferable {
       val newBb = Bufferable.reallocate(bb)
       Bufferable.getBytes(bb).toList == Bufferable.getBytes(newBb).toList &&
       newBb.capacity > bb.capacity &&
-      newBb.position == bb.position
+      newBb.position() == bb.position()
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ import bijection._
 val twitterLibVersion = "20.7.0"
 val scalatestVersion = "3.2.0"
 val scalacheckVersion = "1.14.3"
-val scalatestPlusScalacheckVersion = "3.1.0.0-RC2"
-val scalatestPlusJunitVersion = "1.0.0-M2"
+val scalatestPlusScalacheckVersion = "3.2.0.0"
+val scalatestPlusJunitVersion = "3.2.0.0"
 
 def util(mod: String) =
   "com.twitter" %% (s"util-$mod") % twitterLibVersion % "provided"
@@ -41,9 +41,9 @@ val buildLevelSettings = Seq(
     "releases" at "https://oss.sonatype.org/content/repositories/releases"
   ),
   libraryDependencies ++= Seq(
-    "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
-    "org.scalatest" %% "scalatest" % scalatestVersion % "test",
-    "org.scalatestplus" %% "scalatestplus-scalacheck" % scalatestPlusScalacheckVersion % "test"
+    "org.scalacheck" %% "scalacheck" % scalacheckVersion % Test,
+    "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+    "org.scalatestplus" %% "scalacheck-1-14" % scalatestPlusScalacheckVersion % Test
   ),
   unmanagedSourceDirectories in Compile += {
     val sourceDir = (sourceDirectory in Compile).value
@@ -246,8 +246,8 @@ lazy val bijectionCore = {
   module("core").settings(
     osgiExportAll("com.twitter.bijection"),
     libraryDependencies ++= Seq(
-      "com.novocode" % "junit-interface" % "0.11" % "test",
-      "org.scalatestplus" %% "scalatestplus-junit" % scalatestPlusJunitVersion % "test"
+      "com.novocode" % "junit-interface" % "0.11" % Test,
+      "org.scalatestplus" %% "junit-4-12" % scalatestPlusJunitVersion % Test
     ),
     sourceGenerators in Compile += Def.task {
       val main = (sourceManaged in Compile).value


### PR DESCRIPTION
it would be helpful to me in the Scala 2.13 community build to have this merged

context is https://github.com/scala/community-build/pull/1193