### PR TITLE
allow building on JDK 14

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,8 +23,8 @@ def scroogeSerializer =
 val buildLevelSettings = Seq(
   organization := "com.twitter",
   crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.1"),
-  javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
-  javacOptions in doc := Seq("-source", "1.6", "-Xlint:deprecation", "-Xlint:unchecked"),
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+  javacOptions in doc := Seq("-source", "1.8", "-Xlint:deprecation", "-Xlint:unchecked"),
   scalaVersion := "2.12.10",
   scalacOptions ++= Seq(
     "-unchecked",


### PR DESCRIPTION
on JDK 14, javac no longer accepts "-source 1.6" or "-target 1.6".

in general, Scala OSS projects no longer attempt to support JDK 6 or 7; I assume these flags weren't being kept around on purpose

this came up in the Scala 2.13 community build, here:
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk14-integrate-community-build/1127/artifact/logs/bijection-build.log